### PR TITLE
don't ask for passphrase

### DIFF
--- a/trezor_agent/trezor/_factory.py
+++ b/trezor_agent/trezor/_factory.py
@@ -5,12 +5,16 @@ def client():
     # pylint: disable=import-error
     from trezorlib.client import TrezorClient
     from trezorlib.transport_hid import HidTransport
+    from trezorlib.messages_pb2 import PassphraseAck
+
     devices = HidTransport.enumerate()
     if len(devices) != 1:
         msg = '{:d} Trezor devices found'.format(len(devices))
         raise IOError(msg)
-    return TrezorClient(HidTransport(devices[0]))
 
+    t = TrezorClient(HidTransport(devices[0]))
+    t.callback_PassphraseRequest = lambda msg: PassphraseAck(passphrase='')
+    return t
 
 def identity_type(**kwargs):
     # pylint: disable=import-error


### PR DESCRIPTION
TREZOR Connect does not ask for passphrase and always returns empty one.

I think we should do the same in trezor-agent. Otherwise the user has to enter passphrase twice everytime the agent is used. Passphrase can also create confusion for users unfamiliar of this concept.