### PR TITLE
gpg: replace TREZOR_GPG_USER_ID usage in gpg-agent mode

### DIFF
--- a/README-GPG.md
+++ b/README-GPG.md
@@ -8,7 +8,7 @@ First, verify that you have GPG 2.1+ [installed](https://gist.github.com/vt0r/a2
 
 ```
 $ gpg2 --version | head -n1
-gpg (GnuPG) 2.1.11
+gpg (GnuPG) 2.1.15
 ```
 
 Update you TREZOR firmware to the latest version (at least v1.4.0).
@@ -20,7 +20,7 @@ $ pip install --user git+https://github.com/romanz/trezor-agent.git
 
 Define your GPG user ID as an environment variable:
 ```
-$ export TREZOR_GPG_USER_ID="John Doe <john@doe.bit>"
+$ TREZOR_GPG_USER_ID="John Doe <john@doe.bit>"
 ```
 
 There are two ways to generate TREZOR-based GPG public keys, as described below.
@@ -28,12 +28,12 @@ There are two ways to generate TREZOR-based GPG public keys, as described below.
 ## 1. generate a new GPG identity:
 
 ```
-$ trezor-gpg create | gpg2 --import              # use the TREZOR to confirm signing the primary key
+$ trezor-gpg create "${TREZOR_GPG_USER_ID}" | gpg2 --import           # use the TREZOR to confirm signing the primary key
 gpg: key 5E4D684D: public key "John Doe <john@doe.bit>" imported
 gpg: Total number processed: 1
 gpg:               imported: 1
 
-$ gpg2 --edit "${TREZOR_GPG_USER_ID}" trust      # set this key to ultimate trust (option #5)
+$ gpg2 --edit "${TREZOR_GPG_USER_ID}" trust                           # set this key to ultimate trust (option #5)
 
 $ gpg2 -k
 /home/roman/.gnupg/pubring.kbx
@@ -46,14 +46,14 @@ sub   nistp256/A31D9E25 2016-06-17 [E]
 ## 2. generate a new subkey for an existing GPG identity:
 
 ```
-$ gpg2 -k                                        # suppose there is already a GPG primary key
+$ gpg2 -k                                                             # suppose there is already a GPG primary key
 /home/roman/.gnupg/pubring.kbx
 ------------------------------
 pub   rsa2048/87BB07B4 2016-06-17 [SC]
 uid         [ultimate] John Doe <john@doe.bit>
 sub   rsa2048/7176D31F 2016-06-17 [E]
 
-$ trezor-gpg create --subkey | gpg2 --import     # use the TREZOR to confirm signing the subkey
+$ trezor-gpg create --subkey "${TREZOR_GPG_USER_ID}" | gpg2 --import  # use the TREZOR to confirm signing the subkey
 gpg: key 87BB07B4: "John Doe <john@doe.bit>" 2 new signatures
 gpg: key 87BB07B4: "John Doe <john@doe.bit>" 2 new subkeys
 gpg: Total number processed: 1
@@ -83,13 +83,13 @@ when you are done with the TREZOR-based GPG operations.
 ```
 $ echo "Hello World!" | gpg2 --sign | gpg2 --verify
 gpg: Signature made Fri 17 Jun 2016 08:55:13 PM IDT using ECDSA key ID 5E4D684D
-gpg: Good signature from "Roman Zeyde <roman.zeyde@gmail.com>" [ultimate]
+gpg: Good signature from "John Doe <john@doe.bit>" [ultimate]
 ```
 ## Encrypt and decrypt GPG messages:
 ```
 $ date | gpg2 --encrypt -r "${TREZOR_GPG_USER_ID}" | gpg2 --decrypt
 gpg: encrypted with 256-bit ECDH key, ID A31D9E25, created 2016-06-17
-      "Roman Zeyde <roman.zeyde@gmail.com>"
+      "John Doe <john@doe.bit>"
 Fri Jun 17 20:55:31 IDT 2016
 ```
 

--- a/trezor_agent/gpg/__main__.py
+++ b/trezor_agent/gpg/__main__.py
@@ -3,7 +3,6 @@
 import argparse
 import contextlib
 import logging
-import os
 import sys
 import time
 
@@ -17,17 +16,16 @@ log = logging.getLogger(__name__)
 
 def run_create(args):
     """Generate a new pubkey for a new/existing GPG identity."""
-    user_id = os.environ['TREZOR_GPG_USER_ID']
     log.warning('NOTE: in order to re-generate the exact same GPG key later, '
                 'run this command with "--time=%d" commandline flag (to set '
                 'the timestamp of the GPG key manually).', args.time)
-    conn = device.HardwareSigner(user_id=user_id,
+    conn = device.HardwareSigner(user_id=args.user_id,
                                  curve_name=args.ecdsa_curve)
     verifying_key = conn.pubkey(ecdh=False)
     decryption_key = conn.pubkey(ecdh=True)
 
     if args.subkey:
-        primary_bytes = keyring.export_public_key(user_id=user_id)
+        primary_bytes = keyring.export_public_key(user_id=args.user_id)
         # subkey for signing
         signing_key = protocol.PublicKey(
             curve_name=args.ecdsa_curve, created=args.time,
@@ -37,10 +35,10 @@ def run_create(args):
             curve_name=formats.get_ecdh_curve_name(args.ecdsa_curve),
             created=args.time, verifying_key=decryption_key, ecdh=True)
         result = encode.create_subkey(primary_bytes=primary_bytes,
-                                      pubkey=signing_key,
+                                      subkey=signing_key,
                                       signer_func=conn.sign)
         result = encode.create_subkey(primary_bytes=result,
-                                      pubkey=encryption_key,
+                                      subkey=encryption_key,
                                       signer_func=conn.sign)
     else:
         # primary key for signing
@@ -52,11 +50,11 @@ def run_create(args):
             curve_name=formats.get_ecdh_curve_name(args.ecdsa_curve),
             created=args.time, verifying_key=decryption_key, ecdh=True)
 
-        result = encode.create_primary(user_id=user_id,
+        result = encode.create_primary(user_id=args.user_id,
                                        pubkey=primary,
                                        signer_func=conn.sign)
         result = encode.create_subkey(primary_bytes=result,
-                                      pubkey=subkey,
+                                      subkey=subkey,
                                       signer_func=conn.sign)
 
     sys.stdout.write(protocol.armor(result, 'PUBLIC KEY BLOCK'))
@@ -80,6 +78,7 @@ def main():
     subparsers.dest = 'command'
 
     create_cmd = subparsers.add_parser('create')
+    create_cmd.add_argument('user_id')
     create_cmd.add_argument('-s', '--subkey', action='store_true', default=False)
     create_cmd.add_argument('-e', '--ecdsa-curve', default='nist256p1')
     create_cmd.add_argument('-t', '--time', type=int, default=int(time.time()))

--- a/trezor_agent/gpg/keyring.py
+++ b/trezor_agent/gpg/keyring.py
@@ -184,7 +184,7 @@ def gpg_command(args, env=None):
 def get_keygrip(user_id, sp=subprocess):
     """Get a keygrip of the primary GPG key of the specified user."""
     args = gpg_command(['--list-keys', '--with-keygrip', user_id])
-    output = sp.check_output(args)
+    output = sp.check_output(args).decode('ascii')
     return re.findall(r'Keygrip = (\w+)', output)[0]
 
 
@@ -204,6 +204,12 @@ def export_public_key(user_id, sp=subprocess):
         log.error('could not find public key %r in local GPG keyring', user_id)
         raise KeyError(user_id)
     return result
+
+
+def export_public_keys(sp=subprocess):
+    """Export all GPG public keys."""
+    args = gpg_command(['--export'])
+    return sp.check_output(args=args)
 
 
 def create_agent_signer(user_id):


### PR DESCRIPTION
Use the keygrip to find the correct public key instead of using environment variable.