### PR TITLE
Allow loading multiple identities from a file (e.g. ~/.ssh/config)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
     ],
     entry_points={'console_scripts': [
         'trezor-agent = trezor_agent.__main__:run_agent',
-        'trezor-git = trezor_agent.__main__:run_git',
         'trezor-gpg-create = trezor_agent.gpg.__main__:main_create',
         'trezor-gpg-agent = trezor_agent.gpg.__main__:main_agent',
         'trezor-gpg-unlock = trezor_agent.gpg.__main__:auto_unlock',

--- a/trezor_agent/__main__.py
+++ b/trezor_agent/__main__.py
@@ -164,31 +164,3 @@ def run_agent(client_factory=client.Client):
         pk['identity'] = identity
     return run_server(conn=conn, public_keys=public_keys, command=command,
                       debug=args.debug, timeout=args.timeout)
-
-
-@handle_connection_error
-def run_git(client_factory=client.Client):
-    """Run git under ssh-agent using given hardware client factory."""
-    args = create_git_parser().parse_args()
-    util.setup_logging(verbosity=args.verbose)
-
-    with client_factory(curve=args.ecdsa_curve_name) as conn:
-        label = git_host(args.remote, ['pushurl', 'url'])
-        if not label:
-            log.error('Could not find "%s" SSH remote in .git/config',
-                      args.remote)
-            return
-
-        public_key = conn.get_public_key(label=label)
-
-        if not args.test:
-            if args.command:
-                command = ['git'] + args.command
-            else:
-                sys.stdout.write(public_key)
-                return
-        else:
-            command = ['ssh', '-T', label]
-
-        return run_server(conn=conn, public_key=public_key, command=command,
-                          debug=args.debug, timeout=args.timeout)

--- a/trezor_agent/__main__.py
+++ b/trezor_agent/__main__.py
@@ -120,7 +120,7 @@ def handle_connection_error(func):
 def parse_config(fname):
     """Parse config file into a list of Identity objects."""
     contents = open(fname).read()
-    for identity_str, curve_name in re.findall('\<(.*?)\|(.*?)\>', contents):
+    for identity_str, curve_name in re.findall(r'\<(.*?)\|(.*?)\>', contents):
         yield device.interface.Identity(identity_str=identity_str,
                                         curve_name=curve_name)
 

--- a/trezor_agent/device/__init__.py
+++ b/trezor_agent/device/__init__.py
@@ -24,5 +24,4 @@ def detect():
                 return d
         except interface.NotFoundError as e:
             log.debug('device not found: %s', e)
-    raise IOError('No device found: "{}" ({})'.format(identity_str,
-                                                      curve_name))
+    raise IOError('No device found!')

--- a/trezor_agent/device/__init__.py
+++ b/trezor_agent/device/__init__.py
@@ -16,11 +16,11 @@ DEVICE_TYPES = [
 ]
 
 
-def detect(identity_str, curve_name):
+def detect():
     """Detect the first available device and return it to the user."""
     for device_type in DEVICE_TYPES:
         try:
-            with device_type(identity_str, curve_name) as d:
+            with device_type() as d:
                 return d
         except interface.NotFoundError as e:
             log.debug('device not found: %s', e)

--- a/trezor_agent/device/interface.py
+++ b/trezor_agent/device/interface.py
@@ -45,20 +45,6 @@ def identity_to_string(identity_dict):
     return ''.join(result)
 
 
-def get_bip32_address(identity_dict, ecdh=False):
-    """Compute BIP32 derivation address according to SLIP-0013/0017."""
-    index = struct.pack('<L', identity_dict.get('index', 0))
-    addr = index + identity_to_string(identity_dict).encode('ascii')
-    log.debug('bip32 address string: %r', addr)
-    digest = hashlib.sha256(addr).digest()
-    s = io.BytesIO(bytearray(digest))
-
-    hardened = 0x80000000
-    addr_0 = [13, 17][bool(ecdh)]
-    address_n = [addr_0] + list(util.recv(s, '<LLLL'))
-    return [(hardened | value) for value in address_n]
-
-
 class Error(Exception):
     """Device-related error."""
 
@@ -71,18 +57,49 @@ class DeviceError(Error):
     """"Error during device operation."""
 
 
-class Device(object):
-    """Abstract cryptographic hardware device interface."""
+class Identity(object):
+    """Represent SLIP-0013 identity, together with a elliptic curve choice."""
 
     def __init__(self, identity_str, curve_name):
         """Configure for specific identity and elliptic curve usage."""
         self.identity_dict = string_to_identity(identity_str)
         self.curve_name = curve_name
-        self.conn = None
 
-    def identity_str(self):
+    def items(self):
+        """Return a copy of identity_dict items."""
+        return self.identity_dict.items()
+
+    def __str__(self):
         """Return identity serialized to string."""
-        return identity_to_string(self.identity_dict)
+        return '<{}|{}>'.format(identity_to_string(self.identity_dict), self.curve_name)
+
+    def get_bip32_address(self, ecdh=False):
+        """Compute BIP32 derivation address according to SLIP-0013/0017."""
+        index = struct.pack('<L', self.identity_dict.get('index', 0))
+        addr = index + identity_to_string(self.identity_dict).encode('ascii')
+        log.debug('bip32 address string: %r', addr)
+        digest = hashlib.sha256(addr).digest()
+        s = io.BytesIO(bytearray(digest))
+
+        hardened = 0x80000000
+        addr_0 = [13, 17][bool(ecdh)]
+        address_n = [addr_0] + list(util.recv(s, '<LLLL'))
+        return [(hardened | value) for value in address_n]
+
+    def get_curve_name(self, ecdh=False):
+        """Return correct curve name for device operations."""
+        if ecdh:
+            return formats.get_ecdh_curve_name(self.curve_name)
+        else:
+            return self.curve_name
+
+
+class Device(object):
+    """Abstract cryptographic hardware device interface."""
+
+    def __init__(self):
+        """C-tor."""
+        self.conn = None
 
     def connect(self):
         """Connect to device, otherwise raise NotFoundError."""
@@ -101,25 +118,18 @@ class Device(object):
             log.exception('close failed: %s', e)
         self.conn = None
 
-    def pubkey(self, ecdh=False):
+    def pubkey(self, identity, ecdh=False):
         """Get public key (as bytes)."""
         raise NotImplementedError()
 
-    def sign(self, blob):
+    def sign(self, identity, blob):
         """Sign given blob and return the signature (as bytes)."""
         raise NotImplementedError()
 
-    def ecdh(self, pubkey):
+    def ecdh(self, identity, pubkey):
         """Get shared session key using Elliptic Curve Diffie-Hellman."""
         raise NotImplementedError()
 
     def __str__(self):
         """Human-readable representation."""
         return '{}'.format(self.__class__.__name__)
-
-    def get_curve_name(self, ecdh=False):
-        """Return correct curve name for device operations."""
-        if ecdh:
-            return formats.get_ecdh_curve_name(self.curve_name)
-        else:
-            return self.curve_name

--- a/trezor_agent/device/keepkey.py
+++ b/trezor_agent/device/keepkey.py
@@ -1,7 +1,6 @@
 """KeepKey-related code (see https://www.keepkey.com/)."""
 
 from . import interface, trezor
-from .. import formats
 
 
 class KeepKey(trezor.Trezor):

--- a/trezor_agent/device/keepkey.py
+++ b/trezor_agent/device/keepkey.py
@@ -11,15 +11,7 @@ class KeepKey(trezor.Trezor):
 
     required_version = '>=1.0.4'
 
-    def connect(self):
-        """No support for other than NIST256P elliptic curves."""
-        if self.curve_name not in {formats.CURVE_NIST256}:
-            fmt = 'KeepKey does not support {} curve'
-            raise interface.NotFoundError(fmt.format(self.curve_name))
-
-        return trezor.Trezor.connect(self)
-
-    def ecdh(self, pubkey):
+    def ecdh(self, identity, pubkey):
         """No support for ECDH in KeepKey firmware."""
         msg = 'KeepKey does not support ECDH'
         raise interface.NotFoundError(msg)

--- a/trezor_agent/gpg/__main__.py
+++ b/trezor_agent/gpg/__main__.py
@@ -123,5 +123,5 @@ def auto_unlock():
 
     args = p.parse_args()
     util.setup_logging(verbosity=args.verbose)
-    d = device.detect(identity_str='', curve_name='')
+    d = device.detect()
     log.info('unlocked %s device', d)

--- a/trezor_agent/gpg/client.py
+++ b/trezor_agent/gpg/client.py
@@ -15,8 +15,8 @@ class Client(object):
         self.device = device.detect()
         self.user_id = user_id
         self.identity = device.interface.Identity(
-            identity_str='gpg://{}'.format(user_id),
-            curve_name=curve_name)
+            identity_str='gpg://', curve_name=curve_name)
+        self.identity.identity_dict['host'] = user_id
 
     def pubkey(self, ecdh=False):
         """Return public key as VerifyingKey object."""

--- a/trezor_agent/protocol.py
+++ b/trezor_agent/protocol.py
@@ -140,7 +140,7 @@ class Handler(object):
         label = key['name'].decode('ascii')  # label should be a string
         log.debug('signing %d-byte blob with "%s" key', len(blob), label)
         try:
-            signature = self.signer(blob=blob)
+            signature = self.signer(blob=blob, identity=key['identity'])
         except IOError:
             return failure()
         log.debug('signature: %r', signature)


### PR DESCRIPTION
This should allow using `trezor-agent` with minimal command-line configuration (see #75).