### PR TITLE
Mosh doesn't support "-l" for user, only user@host for args

### DIFF
--- a/trezor_agent/__main__.py
+++ b/trezor_agent/__main__.py
@@ -25,6 +25,21 @@ def ssh_args(label):
     return args + [identity['host']]
 
 
+def mosh_args(label):
+    """Create SSH command for connecting specified server."""
+    identity = device.interface.string_to_identity(label)
+
+    args = []
+    if 'port' in identity:
+        args += ['-p', identity['port']]
+    if 'user' in identity:
+        args += [identity['user']+'@'+identity['host']]
+    else:
+        args += [identity['host']]
+
+    return args
+
+
 def create_parser():
     """Create argparse.ArgumentParser for this tool."""
     p = argparse.ArgumentParser()
@@ -148,7 +163,7 @@ def run_agent(client_factory=client.Client):
     if args.connect:
         command = ['ssh'] + ssh_args(args.identity) + args.command
     elif args.mosh:
-        command = ['mosh'] + ssh_args(args.identity) + args.command
+        command = ['mosh'] + mosh_args(args.identity) + args.command
     else:
         command = args.command
 


### PR DESCRIPTION
This is the error you get currently when trying to connect with mosh and specifying a login user:

```
$ trezor-agent -e ed25519 myuser@myhost --mosh -v
2016-12-14 23:53:05,770 INFO         identity #0: <ssh://myuser@myhost|ed25519>                                                       [__main__.py:144]
2016-12-14 23:53:06,332 INFO         running ['mosh', '-l', 'myuser', 'myhost'] with {'SSH_AUTH_SOCK': '/tmp/trezor-ssh-agent-hXtrRY', 'SSH_AGENT_PID': '16079'} [server.py:156]
Unknown option: l
Usage: /usr/bin/mosh [options] [--] [user@]host [command...]
        --client=PATH        mosh client on local machine
                                (default: "mosh-client")
        --server=COMMAND     mosh server on remote machine
                                (default: "mosh-server")

        --predict=adaptive      local echo for slower links [default]
-a      --predict=always        use local echo even on fast links
-n      --predict=never         never use local echo
        --predict=experimental  aggressively echo even when incorrect

-4      --family=inet        use IPv4 only [default]
-6      --family=inet6       use IPv6 only
-p PORT[:PORT2]
        --port=PORT[:PORT2]  server-side UDP port or range
        --bind-server={ssh|any|IP}  ask the server to reply from an IP address
                                       (default: "ssh")

        --ssh=COMMAND        ssh command to run when setting up session
                                (example: "ssh -p 2222")
                                (default: "ssh")

        --no-init            do not send terminal initialization string

        --help               this message
        --version            version and copyright information

Please report bugs to mosh-devel@mit.edu.
Mosh home page: http://mosh.mit.edu
```