### PR TITLE
Allow contents in buffer when using _legacy_pubs

### DIFF
--- a/trezor_agent/protocol.py
+++ b/trezor_agent/protocol.py
@@ -60,7 +60,7 @@ def failure():
     return util.frame(error_msg)
 
 
-def _legacy_pubs(buf):
+def _legacy_pubs(_):
     """SSH v1 public keys are not supported."""
     code = util.pack('B', msg_code('SSH_AGENT_RSA_IDENTITIES_ANSWER'))
     num = util.pack('L', 0)  # no SSH v1 keys

--- a/trezor_agent/protocol.py
+++ b/trezor_agent/protocol.py
@@ -62,7 +62,6 @@ def failure():
 
 def _legacy_pubs(buf):
     """SSH v1 public keys are not supported."""
-    assert not buf.read()
     code = util.pack('B', msg_code('SSH_AGENT_RSA_IDENTITIES_ANSWER'))
     num = util.pack('L', 0)  # no SSH v1 keys
     return util.frame(code, num)


### PR DESCRIPTION
Hi,
I'm trying to use trezor-agent to automate deploys via capistrano in a rails app.
In case you're not familiar with it, Capistrano is a tool that uses a pure-ruby SSH client library to connect to servers and perform tasks on them. It uses non-interactive / non-login shells.

When running capistrano inside a trezor-agent shell, it made the agent crash on an assertion error in the _legacy_pubs method in protocol.py

I'm using ubuntu linux, capistrano communicates with trezor-agent via a unix socket.

It seems the _legacy_pubs expects the buffer to be empty otherwise it refuses to continue, but I don't know why.

When capistrano tried to connect to the trezor-agent the contents in 'buf' were as follows:

(Pdb) list
 61  	
 62  	
 63  	def _legacy_pubs(buf):
 64  	    """SSH v1 public keys are not supported."""
 65  	    import pdb; pdb.set_trace()
 66  ->	    assert not buf.read()
 67  	    code = util.pack('B', msg_code('SSH_AGENT_RSA_IDENTITIES_ANSWER'))
 68  	    num = util.pack('L', 0)  # no SSH v1 keys
 69  	    return util.frame(code, num)
 70  	
 71  	
(Pdb) buf.read()
'\x00\x00\x00(SSH-2.0-Ruby/Net::SSH_4.1.0 x86_64-linux'

Just removing that check made everything work for me. I'm guessing it was added to deal with quirks on other platforms (?). 

I don't expect this pull request to get merged though, just get the conversation going, as I'm not really sure about what I've just removed. Maybe there's some configuration in capistrano that won't make it use the legacy_pubs method.

Best regards.
----nubis