### PR TITLE
Allow contents in buffer when using _legacy_pubs

### DIFF
--- a/trezor_agent/protocol.py
+++ b/trezor_agent/protocol.py
@@ -62,7 +62,9 @@ def failure():
 
 def _legacy_pubs(buf):
     """SSH v1 public keys are not supported."""
-    assert not buf.read()
+    leftover = buf.read()
+    if leftover:
+        log.warning('skipping leftover: %r', leftover)
     code = util.pack('B', msg_code('SSH_AGENT_RSA_IDENTITIES_ANSWER'))
     num = util.pack('L', 0)  # no SSH v1 keys
     return util.frame(code, num)

--- a/trezor_agent/tests/test_protocol.py
+++ b/trezor_agent/tests/test_protocol.py
@@ -31,6 +31,13 @@ def test_list():
     assert reply == LIST_NIST256_REPLY
 
 
+def test_list_legacy_pubs_with_suffix():
+    h = protocol.Handler(fake_connection(keys=[], signer=None))
+    suffix = b'\x00\x00\x00\x06foobar'
+    reply = h.handle(b'\x01' + suffix)
+    assert reply == b'\x00\x00\x00\x05\x02\x00\x00\x00\x00'  # no legacy keys
+
+
 def test_unsupported():
     h = protocol.Handler(fake_connection(keys=[], signer=None))
     reply = h.handle(b'\x09')


### PR DESCRIPTION
Fix Capistrano compatibility issue described at #99.