### PR TITLE
Cache SSH public keys for the duration of the agent

### DIFF
--- a/trezor_agent/__main__.py
+++ b/trezor_agent/__main__.py
@@ -147,8 +147,9 @@ class JustInTimeConnection(object):
         """Create a JIT connection object."""
         self.conn_factory = conn_factory
         self.identities = identities
+        self.public_keys = util.memoize(self._public_keys)  # a simple cache
 
-    def public_keys(self):
+    def _public_keys(self):
         """Return a list of SSH public keys (in textual format)."""
         conn = self.conn_factory()
         return [conn.get_public_key(i) for i in self.identities]


### PR DESCRIPTION
This saves a lot of time when connecting to multiple hosts simultaneously (e.g., during a deploy) as every time we are asked to sign a challenge, all public keys are iterated to find the correct one. 
This can become especially slow when using the Bridge transport and/or many identities are defined.