### PR TITLE
ssh: fix identity stringification

### DIFF
--- a/libagent/ssh/client.py
+++ b/libagent/ssh/client.py
@@ -42,7 +42,7 @@ class Client(object):
         log.debug('hidden challenge size: %d bytes', len(blob))
 
         log.info('please confirm user "%s" login to "%s" using %s...',
-                 msg['user'].decode('ascii'), identity,
+                 msg['user'].decode('ascii'), identity.to_string(),
                  self.device)
 
         with self.device:


### PR DESCRIPTION
The log contained `.__str__()` result (instead of `.to_string()`):
```
2017-10-05 18:11:56,170 INFO         please confirm user "git" login to \
"<libagent.device.interface.Identity object at 0x7f07e20e1a10>" using Trezor... [client.py:46]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/romanz/trezor-agent/138)
<!-- Reviewable:end -->
