### PR TITLE
README: Add a note about how to fetch a key's timestamp

### DIFF
--- a/README-GPG.md
+++ b/README-GPG.md
@@ -103,3 +103,10 @@ $ GNUPGHOME=~/.gnupg/trezor qtpass
 
 ## Re-generation of an existing GPG identity
 [![asciicast](https://asciinema.org/a/M4lRjEmGJ2RreQiHBGWT9pzp4.png)](https://asciinema.org/a/M4lRjEmGJ2RreQiHBGWT9pzp4)
+
+If you've forgotten the timestamp value, but still have access to the public key, then you can
+retrieve the timestamp with the following command (substitute "john@doe.bit" for the key's address or id):
+
+```
+$ gpg2 --export 'john@doe.bit'|gpg2 --list-packets|grep created|head -n1
+```


### PR DESCRIPTION
I found your reddit post here https://www.reddit.com/r/TREZOR/comments/64k139/gpg_and_trezor_questions/dg6cwmc/?context=2 useful. But then when I needed the information again later, it took me a while to find it again. I think it would be useful to have in the readme, which this pull request does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/romanz/trezor-agent/143)
<!-- Reviewable:end -->
