### PR TITLE
Allow the user to configure a pinentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ Currently [TREZOR](https://trezor.io/), [Keepkey](https://www.keepkey.com/), and
     Note: If you're using Windows, see [trezor-ssh-agent](https://github.com/martin-lizner/trezor-ssh-agent) by Martin Lízner.
 
 * **GPG** instructions and common use cases are [here](doc/README-GPG.md)
+* Instructions to configure a Trezor-style **PIN entry** program are [here](doc/README-PINENTRY.md)

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -65,7 +65,9 @@ gpg (GnuPG) 2.1.15
     $ pip install --user -e trezor-agent/agents/trezor
     ```
 
-    Read [these instructions](https://github.com/romanz/python-trezor#pin-entering) on how to enter your PIN with the PIN entry.
+    Read [these instructions](https://github.com/romanz/python-trezor#pin-entering) on how to enter your PIN with the default PIN entry.
+
+    If you'd like a Trezor-style PIN entry program, follow [these instructions](README-PINENTRY.md).
 
 # 3. Install the KeepKey agent
 
@@ -86,6 +88,8 @@ Then, install the latest [keepkey_agent](https://pypi.python.org/pypi/keepkey_ag
     $ git clone https://github.com/romanz/trezor-agent
     $ pip install --user -e trezor-agent/agents/keepkey
     ```
+
+    Read [these instructions](https://github.com/romanz/python-trezor#pin-entering) on how to enter your PIN with the default PIN entry.
 
 # 4. Install the Ledger Nano S agent
 

--- a/doc/README-GPG.md
+++ b/doc/README-GPG.md
@@ -23,6 +23,8 @@ Thanks!
 
     Follow the instructions provided to complete the setup.  Keep note of the timestamp value which you'll need if you want to regenerate the key later.
 
+    If you'd like a Trezor-style PIN entry program, follow [these instructions](README-PINENTRY.md).
+
 2. Add `export GNUPGHOME=~/.gnupg/(trezor|keepkey|ledger)` to your `.bashrc` or other environment file.
 
     This `GNUPGHOME` contains your hardware keyring and agent settings.  This agent software assumes all keys are backed by hardware devices so you can't use standard GPG keys in `GNUPGHOME` (if you do mix keys you'll receive an error when you attempt to use them).

--- a/doc/README-PINENTRY.md
+++ b/doc/README-PINENTRY.md
@@ -1,0 +1,58 @@
+# Custom PIN entry
+
+By default a standard GPG PIN entry program is used when entering your Trezor PIN, but it's difficult to use if you don't have a numeric keypad or want to use your mouse.
+
+You can specify a custom PIN entry program (and separately, a passphrase entry program) such as [trezor-gpg-pinentry-tk](https://github.com/rendaw/trezor-gpg-pinentry-tk) to match your workflow.
+
+##### 1. Install the PIN entry
+
+Run
+
+```
+pip install trezor-gpg-pinentry-tk
+```
+
+##### 2. SSH
+
+Add the flag `--pinentry trezor-gpg-pinentry-tk` to all calls to `trezor-agent`.
+
+To automatically use this flag, add the line `pinentry=trezor-gpg-pinentry-tk` to `~/.ssh/agent.config`.  **Note** this is currently broken due to [this dependency issue](https://github.com/bw2/ConfigArgParse/issues/114).
+
+If you specify the flag in a systemd `.service` file you may need to use the absolute path to `trezor-gpg-pinentry-tk`.  You may also need to add this line:
+
+```
+Environment="DISPLAY=:0"
+```
+
+to the `[Service]` section to tell the PIN entry program how to connect to the X11 server.
+
+##### 3. GPG
+
+If you haven't completed initialization yet, run:
+
+```
+$ (trezor|keepkey|ledger)-gpg init --pinentry trezor-gpg-pinentry-tk "Roman Zeyde <roman.zeyde@gmail.com>"
+```
+
+to configure the PIN entry at the same time.
+
+Otherwise, open `$GNUPGHOME/trezor/gpg-agent.conf` and add this line:
+
+```
+pinentry-program trezor-gpg-pinentry-tk
+```
+
+Kill the agent (processes `run-agent.sh` and `trezor-gpg-agent`).
+
+##### 4. Troubleshooting
+
+Add:
+
+```
+log-file /home/yourname/.gnupg/trezor/gpg-agent.log
+verbosity 2
+```
+
+to `$GNUPGHOME/trezor/gpg-agent.conf` and restart the agent.
+
+Any problems running the PIN entry program should appear in the log file.

--- a/doc/README-SSH.md
+++ b/doc/README-SSH.md
@@ -6,6 +6,8 @@ SSH requires no configuration, but you may put common command line options in `~
 
 See `(trezor|keepkey|ledger)-agent -h` for details on supported options and the configuration file format.
 
+If you'd like a Trezor-style PIN entry program, follow [these instructions](README-PINENTRY.md).
+
 ## 2. Usage
 
 Use the `(trezor|keepkey|ledger)-agent` program to work with SSH. It has three main modes of operation:

--- a/libagent/device/fake_device.py
+++ b/libagent/device/fake_device.py
@@ -43,7 +43,7 @@ class FakeDevice(interface.Device):
         """Close connection."""
         self.conn = None
 
-    def pubkey(self, identity, ecdh=False):
+    def pubkey(self, identity, ecdh=False, options=None):
         """Return public key."""
         _verify_support(identity)
         data = self.vk.to_string()
@@ -51,7 +51,7 @@ class FakeDevice(interface.Device):
         prefix = bytearray([2 + (bytearray(y)[0] & 1)])
         return bytes(prefix) + x
 
-    def sign(self, identity, blob):
+    def sign(self, identity, blob, options=None):
         """Sign given blob and return the signature (as bytes)."""
         if identity.identity_dict['proto'] in {'ssh'}:
             digest = hashlib.sha256(blob).digest()
@@ -60,7 +60,7 @@ class FakeDevice(interface.Device):
         return self.sk.sign_digest_deterministic(digest=digest,
                                                  hashfunc=hashlib.sha256)
 
-    def ecdh(self, identity, pubkey):
+    def ecdh(self, identity, pubkey, options=None):
         """Get shared session key using Elliptic Curve Diffie-Hellman."""
         assert pubkey[:1] == b'\x04'
         peer = ecdsa.VerifyingKey.from_string(

--- a/libagent/device/interface.py
+++ b/libagent/device/interface.py
@@ -105,7 +105,7 @@ class Identity(object):
 class Device(object):
     """Abstract cryptographic hardware device interface."""
 
-    def __init__(self, config=None):
+    def __init__(self, config=None):  # pylint: disable=unused-argument
         """C-tor."""
         self.conn = None
 

--- a/libagent/device/interface.py
+++ b/libagent/device/interface.py
@@ -105,7 +105,7 @@ class Identity(object):
 class Device(object):
     """Abstract cryptographic hardware device interface."""
 
-    def __init__(self):
+    def __init__(self, config=None):
         """C-tor."""
         self.conn = None
 
@@ -126,15 +126,15 @@ class Device(object):
             log.exception('close failed: %s', e)
         self.conn = None
 
-    def pubkey(self, identity, ecdh=False):
+    def pubkey(self, identity, ecdh=False, options=None):
         """Get public key (as bytes)."""
         raise NotImplementedError()
 
-    def sign(self, identity, blob):
+    def sign(self, identity, blob, options=None):
         """Sign given blob and return the signature (as bytes)."""
         raise NotImplementedError()
 
-    def ecdh(self, identity, pubkey):
+    def ecdh(self, identity, pubkey, options=None):
         """Get shared session key using Elliptic Curve Diffie-Hellman."""
         raise NotImplementedError()
 

--- a/libagent/device/keepkey.py
+++ b/libagent/device/keepkey.py
@@ -32,11 +32,12 @@ class KeepKey(trezor.Trezor):
 
     required_version = '>=1.0.4'
 
-    def pubkey(self, identity, ecdh=False):
+    def pubkey(self, identity, ecdh=False, options=None):
         """Return public key."""
         _verify_support(identity, ecdh)
-        return trezor.Trezor.pubkey(self, identity=identity, ecdh=ecdh)
+        return trezor.Trezor.pubkey(self, identity=identity, ecdh=ecdh,
+                                    options=options)
 
-    def ecdh(self, identity, pubkey):
+    def ecdh(self, identity, pubkey, options=None):
         """No support for ECDH in KeepKey firmware."""
         _verify_support(identity, ecdh=True)

--- a/libagent/device/ledger.py
+++ b/libagent/device/ledger.py
@@ -41,6 +41,10 @@ class LedgerNanoS(interface.Device):
         """Python package name (at PyPI)."""
         return 'ledger-agent'
 
+    def __init__(self, config=None):
+        self.config = config
+        super(LedgerNanoS, self).__init__(config=config)
+
     def connect(self):
         """Enumerate and connect to the first USB HID interface."""
         try:
@@ -49,7 +53,7 @@ class LedgerNanoS(interface.Device):
             raise interface.NotFoundError(
                 '{} not connected: "{}"'.format(self, e))
 
-    def pubkey(self, identity, ecdh=False):
+    def pubkey(self, identity, ecdh=False, options=None):
         """Get PublicKey object for specified BIP32 address and elliptic curve."""
         curve_name = identity.get_curve_name(ecdh)
         path = _expand_path(identity.get_bip32_address(ecdh))
@@ -66,7 +70,7 @@ class LedgerNanoS(interface.Device):
         log.debug('result: %r', result)
         return _convert_public_key(curve_name, result[1:])
 
-    def sign(self, identity, blob):
+    def sign(self, identity, blob, options=None):
         """Sign given blob and return the signature (as bytes)."""
         path = _expand_path(identity.get_bip32_address(ecdh=False))
         if identity.identity_dict['proto'] == 'ssh':
@@ -103,7 +107,7 @@ class LedgerNanoS(interface.Device):
         else:
             return bytes(result[:64])
 
-    def ecdh(self, identity, pubkey):
+    def ecdh(self, identity, pubkey, options=None):
         """Get shared session key using Elliptic Curve Diffie-Hellman."""
         path = _expand_path(identity.get_bip32_address(ecdh=True))
         if identity.curve_name == 'nist256p1':

--- a/libagent/device/ledger.py
+++ b/libagent/device/ledger.py
@@ -41,10 +41,6 @@ class LedgerNanoS(interface.Device):
         """Python package name (at PyPI)."""
         return 'ledger-agent'
 
-    def __init__(self, config=None):
-        self.config = config
-        super(LedgerNanoS, self).__init__(config=config)
-
     def connect(self):
         """Enumerate and connect to the first USB HID interface."""
         try:

--- a/libagent/device/trezor.py
+++ b/libagent/device/trezor.py
@@ -70,7 +70,7 @@ def _pin_communicate(program, message, error=None, options=None):
         else:
             send('OPTION {}'.format(k))
         expect('OK')
-    send('SETDESC {}'.format(message))
+    send('SETDESC {}'.format(' '.join(message.splitlines())))
     expect('OK')
     if error:
         send('SETERROR {}'.format(error))

--- a/libagent/device/trezor.py
+++ b/libagent/device/trezor.py
@@ -44,7 +44,7 @@ def _pin_communicate(program, message, error=None, options=None):
         )
     except OSError as e:
         if e.errno == os.errno.ENOENT:
-            log.debug('Couldn\'t find pin/pass entry program {}'.format(program))
+            log.debug('Couldn\'t find pin/pass entry program %s', program)
             return None
         else:
             raise

--- a/libagent/device/trezor.py
+++ b/libagent/device/trezor.py
@@ -82,7 +82,7 @@ def _pin_communicate(program, message, error=None, options=None):
     entry.stdin.close()
     try:
         entry.communicate()
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         pass
     return result
 
@@ -220,7 +220,7 @@ class Trezor(interface.Device):
                 except (self._defs.PinException, ValueError) as e:
                     log.error('Invalid PIN: %s, retrying...', e)
                     continue
-                except Exception as e:
+                except Exception as e:  # pylint: disable=broad-except
                     log.exception('ping failed: %s', e)
                     connection.close()  # so the next HID open() will succeed
 

--- a/libagent/device/trezor.py
+++ b/libagent/device/trezor.py
@@ -164,7 +164,7 @@ class Trezor(interface.Device):
                 return self.__class__.cached_passphrase_ack
 
             ack = None
-            passphrase_program = self.config.get('passphrase-program')
+            passphrase_program = self.config.get('passentry-program')
             passphrase = _pin_communicate(
                 self,
                 passphrase_program or 'pinentry',

--- a/libagent/device/trezor.py
+++ b/libagent/device/trezor.py
@@ -44,6 +44,7 @@ def _pin_communicate(program, message, error=None, options=None):
         )
     except OSError as e:
         if e.errno == os.errno.ENOENT:
+            log.debug('Couldn\'t find pin/pass entry program {}'.format(program))
             return None
         else:
             raise

--- a/libagent/gpg/__init__.py
+++ b/libagent/gpg/__init__.py
@@ -37,7 +37,7 @@ def export_public_key(device_type, args):
     if args.pinentry:
         config['pinentry-program'] = args.pinentry
     if args.passentry:
-        config['passphrase-program'] = args.passentry
+        config['passentry-program'] = args.passentry
     c = client.Client(device=device_type(config=config))
     identity = client.create_identity(user_id=args.user_id,
                                       curve_name=args.ecdsa_curve)

--- a/libagent/gpg/__init__.py
+++ b/libagent/gpg/__init__.py
@@ -214,7 +214,11 @@ def run_agent(device_type):
     args, _ = parser.parse_known_args()
 
     assert args.homedir
-    config = util.parse_config(args.homedir)
+    config_file = os.path.join(args.homedir, 'gpg-agent.conf')
+
+    lines = (line.strip() for line in open(config_file))
+    lines = (line for line in lines if line and not line.startswith('#'))
+    config = dict(line.split(' ', 1) for line in lines)
 
     util.setup_logging(verbosity=int(config['verbosity']),
                        filename=config['log-file'])

--- a/libagent/gpg/__init__.py
+++ b/libagent/gpg/__init__.py
@@ -262,8 +262,8 @@ def main(device_type):
     p.add_argument('-t', '--time', type=int, default=int(time.time()))
     p.add_argument('-v', '--verbose', default=0, action='count')
     p.add_argument('-s', '--subkey', default=False, action='store_true')
-    p.add_argument('-p', '--pinentry')
-    p.add_argument('-pa', '--passentry')
+    p.add_argument('--pinentry')
+    p.add_argument('--passentry')
     p.set_defaults(func=run_init)
 
     p = subparsers.add_parser('unlock', help='unlock the hardware device')

--- a/libagent/gpg/__init__.py
+++ b/libagent/gpg/__init__.py
@@ -214,11 +214,7 @@ def run_agent(device_type):
     args, _ = parser.parse_known_args()
 
     assert args.homedir
-    config_file = os.path.join(args.homedir, 'gpg-agent.conf')
-
-    lines = (line.strip() for line in open(config_file))
-    lines = (line for line in lines if line and not line.startswith('#'))
-    config = dict(line.split(' ', 1) for line in lines)
+    config = util.parse_config(args.homedir)
 
     util.setup_logging(verbosity=int(config['verbosity']),
                        filename=config['log-file'])

--- a/libagent/gpg/agent.py
+++ b/libagent/gpg/agent.py
@@ -79,6 +79,7 @@ class AgentStop(Exception):
 
 class Handler(object):
     """GPG agent requests' handler."""
+    # pylint: disable=too-many-instance-attributes
 
     def __init__(self, device, pubkey_bytes):
         """C-tor."""

--- a/libagent/gpg/agent.py
+++ b/libagent/gpg/agent.py
@@ -79,6 +79,7 @@ class AgentStop(Exception):
 
 class Handler(object):
     """GPG agent requests' handler."""
+
     # pylint: disable=too-many-instance-attributes
 
     def __init__(self, device, pubkey_bytes):

--- a/libagent/gpg/agent.py
+++ b/libagent/gpg/agent.py
@@ -111,6 +111,7 @@ class Handler(object):
         }
 
     def set_option(self, args):
+        """Store options passed to the agent."""
         parts = args[0].decode('utf-8').split('=', 1)
         i = iter(parts)
         k = next(i, None)

--- a/libagent/gpg/client.py
+++ b/libagent/gpg/client.py
@@ -22,14 +22,16 @@ class Client(object):
         """C-tor."""
         self.device = device
 
-    def pubkey(self, identity, ecdh=False):
+    def pubkey(self, identity, ecdh=False, options=None):
         """Return public key as VerifyingKey object."""
         with self.device:
-            pubkey = self.device.pubkey(ecdh=ecdh, identity=identity)
+            pubkey = self.device.pubkey(ecdh=ecdh,
+                                        identity=identity,
+                                        options=options)
         return formats.decompress_pubkey(
             pubkey=pubkey, curve_name=identity.curve_name)
 
-    def sign(self, identity, digest):
+    def sign(self, identity, digest, options=None):
         """Sign the digest and return a serialized signature."""
         log.info('please confirm GPG signature on %s for "%s"...',
                  self.device, identity.to_string())
@@ -37,12 +39,16 @@ class Client(object):
             digest = digest[:32]  # sign the first 256 bits
         log.debug('signing digest: %s', util.hexlify(digest))
         with self.device:
-            sig = self.device.sign(blob=digest, identity=identity)
+            sig = self.device.sign(blob=digest,
+                                   identity=identity,
+                                   options=options)
         return (util.bytes2num(sig[:32]), util.bytes2num(sig[32:]))
 
-    def ecdh(self, identity, pubkey):
+    def ecdh(self, identity, pubkey, options=None):
         """Derive shared secret using ECDH from remote public key."""
         log.info('please confirm GPG decryption on %s for "%s"...',
                  self.device, identity.to_string())
         with self.device:
-            return self.device.ecdh(pubkey=pubkey, identity=identity)
+            return self.device.ecdh(pubkey=pubkey,
+                                    identity=identity,
+                                    options=options)

--- a/libagent/ssh/__init__.py
+++ b/libagent/ssh/__init__.py
@@ -100,6 +100,10 @@ def create_agent_parser(device_type):
                    help='proto://[user@]host[:port][/path]')
     p.add_argument('command', type=str, nargs='*', metavar='ARGUMENT',
                    help='command to run under the SSH agent')
+    p.add_argument('--pinentry', help='Configure a GPG PINENTRY program')
+    p.add_argument('--passentry',
+                   help=('Configure a GPG PINENTRY program for passphrase '
+                         'entry'))
     return p
 
 
@@ -255,10 +259,11 @@ def main(device_type):
         command = os.environ['SHELL']
         sys.stdin.close()
 
-    config = {
-        'pinentry-program': args.pinentry,
-        'passentry-program': args.passentry,
-    }
+    config = {}
+    if args.pinentry:
+        config['pinentry-program'] = args.pinentry
+    if args.passentry:
+        config['passentry-program'] = args.passentry
     conn = JustInTimeConnection(
         conn_factory=lambda: client.Client(device_type(config=config)),
         identities=identities, public_keys=public_keys)

--- a/libagent/ssh/__init__.py
+++ b/libagent/ssh/__init__.py
@@ -214,9 +214,11 @@ def _dummy_context():
 @handle_connection_error
 def main(device_type):
     """Run ssh-agent using given hardware client factory."""
+    # pylint: disable=too-many-locals
     args = create_agent_parser(device_type=device_type).parse_args()
     config = util.parse_config()
-    util.setup_logging(verbosity=args.verbose, filename=args.log_file)
+    verbosity = args.verbose or int(config.get('verbosity', 0))
+    util.setup_logging(verbosity=verbosity, filename=args.log_file)
 
     public_keys = None
     if args.identity.startswith('/'):

--- a/libagent/ssh/__init__.py
+++ b/libagent/ssh/__init__.py
@@ -216,9 +216,7 @@ def main(device_type):
     """Run ssh-agent using given hardware client factory."""
     # pylint: disable=too-many-locals
     args = create_agent_parser(device_type=device_type).parse_args()
-    config = util.parse_config()
-    verbosity = args.verbose or int(config.get('verbosity', 0))
-    util.setup_logging(verbosity=verbosity, filename=args.log_file)
+    util.setup_logging(verbosity=args.verbose, filename=args.log_file)
 
     public_keys = None
     if args.identity.startswith('/'):
@@ -257,6 +255,10 @@ def main(device_type):
         command = os.environ['SHELL']
         sys.stdin.close()
 
+    config = {
+        'pinentry-program': args.pinentry,
+        'passentry-program': args.passentry,
+    }
     conn = JustInTimeConnection(
         conn_factory=lambda: client.Client(device_type(config=config)),
         identities=identities, public_keys=public_keys)

--- a/libagent/ssh/__init__.py
+++ b/libagent/ssh/__init__.py
@@ -215,6 +215,7 @@ def _dummy_context():
 def main(device_type):
     """Run ssh-agent using given hardware client factory."""
     args = create_agent_parser(device_type=device_type).parse_args()
+    config = util.parse_config()
     util.setup_logging(verbosity=args.verbose, filename=args.log_file)
 
     public_keys = None
@@ -255,7 +256,7 @@ def main(device_type):
         sys.stdin.close()
 
     conn = JustInTimeConnection(
-        conn_factory=lambda: client.Client(device_type()),
+        conn_factory=lambda: client.Client(device_type(config=config)),
         identities=identities, public_keys=public_keys)
 
     if command or args.daemonize:

--- a/libagent/ssh/__init__.py
+++ b/libagent/ssh/__init__.py
@@ -218,7 +218,7 @@ def _dummy_context():
 @handle_connection_error
 def main(device_type):
     """Run ssh-agent using given hardware client factory."""
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals, too-many-branches
     args = create_agent_parser(device_type=device_type).parse_args()
     util.setup_logging(verbosity=args.verbose, filename=args.log_file)
 

--- a/libagent/ssh/tests/test_client.py
+++ b/libagent/ssh/tests/test_client.py
@@ -20,11 +20,14 @@ class MockDevice(device.interface.Device):  # pylint: disable=abstract-method
     def connect(self):  # pylint: disable=no-self-use
         return mock.Mock()
 
-    def pubkey(self, identity, ecdh=False):  # pylint: disable=unused-argument
+    def pubkey(self,
+               identity,
+               ecdh=False,
+               options=None):  # pylint: disable=unused-argument
         assert self.conn
         return PUBKEY
 
-    def sign(self, identity, blob):
+    def sign(self, identity, blob, options=None):
         """Sign given blob and return the signature (as bytes)."""
         assert self.conn
         assert blob == BLOB

--- a/libagent/util.py
+++ b/libagent/util.py
@@ -5,6 +5,7 @@ import functools
 import io
 import logging
 import struct
+import os
 
 log = logging.getLogger(__name__)
 
@@ -229,3 +230,13 @@ def which(cmd):
         raise OSError('Cannot find {!r} in $PATH'.format(cmd))
     log.debug('which %r => %r', cmd, full_path)
     return full_path
+
+
+def parse_config(homedir=None):
+    if not homedir:
+        homedir = os.environ.get('GNUPGHOME')
+    config_file = os.path.join(homedir, 'gpg-agent.conf')
+    with open(config_file, 'r') as source:
+        lines = (line.strip() for line in source)
+    lines = (line for line in lines if line and not line.startswith('#'))
+    return dict(line.split(' ', 1) for line in lines)

--- a/libagent/util.py
+++ b/libagent/util.py
@@ -233,6 +233,7 @@ def which(cmd):
 
 
 def parse_config(homedir=None):
+    """Load the gpg-agent config."""
     if not homedir:
         homedir = os.environ.get('GNUPGHOME')
     config_file = os.path.join(homedir, 'gpg-agent.conf')

--- a/libagent/util.py
+++ b/libagent/util.py
@@ -5,7 +5,6 @@ import functools
 import io
 import logging
 import struct
-import os
 
 log = logging.getLogger(__name__)
 
@@ -230,14 +229,3 @@ def which(cmd):
         raise OSError('Cannot find {!r} in $PATH'.format(cmd))
     log.debug('which %r => %r', cmd, full_path)
     return full_path
-
-
-def parse_config(homedir=None):
-    """Load the gpg-agent config."""
-    if not homedir:
-        homedir = os.environ.get('GNUPGHOME')
-    config_file = os.path.join(homedir, 'gpg-agent.conf')
-    with open(config_file, 'r') as source:
-        lines = (line.strip() for line in source)
-    lines = (line for line in lines if line and not line.startswith('#'))
-    return dict(line.split(' ', 1) for line in lines)


### PR DESCRIPTION
(and optionally a passphrase entry).

It uses `pinentry` by default, which should be available if gpg is installed, then falls back to the existing builtin pinentry.  I also had to parse the options passed to the agent to pass them to the pinentry - this communicates things like the X11 display and user's current TTY so the pinentry can communicate properly.