### PR TITLE
Add instructions for using SSH agent as systemd unit

### DIFF
--- a/doc/README-SSH.md
+++ b/doc/README-SSH.md
@@ -85,3 +85,55 @@ Note that your local SSH configuration may ignore `trezor-agent`, if it has `Ide
 If you are failing to connect, try running:
 
     $ trezor-agent -vv user@host -- ssh -vv -oIdentitiesOnly=no user@host
+
+# Start the agent as a systemd unit
+
+##### 1. Create these files in `~/.config/systemd/user`
+
+Replace `trezor` with `keepkey` or `ledger` as required.
+
+###### `trezor-ssh-agent.service`
+
+````
+[Unit]
+Description=trezor-agent SSH agent
+Requires=trezor-ssh-agent.socket
+
+[Service]
+Type=Simple
+ExecStart=/usr/bin/trezor-agent --sock-path %t/trezor-agent/S.ssh IDENTITY -- tail -f /dev/null
+````
+
+Replace `IDENTITY` with the identity you used when exporting the public key.
+
+###### `trezor-ssh-agent.socket`
+
+````
+[Unit]
+Description=trezor-agent SSH agent socket
+
+[Socket]
+ListenStream=%t/trezor-agent/S.ssh
+FileDescriptorName=ssh
+Service=trezor-ssh-agent.service
+SocketMode=0600
+DirectoryMode=0700
+
+[Install]
+WantedBy=sockets.target
+````
+
+##### 2. Run
+
+```
+systemctl --user start trezor-ssh-agent.service trezor-ssh-agent.socket
+systemctl --user enable trezor-ssh-agent.socket
+```
+
+##### 3. Add this line to your `.bashrc` or equivalent file:
+
+```bash
+export SSH_AUTH_SOCK=$(systemctl show --user --property=Listen trezor-ssh-agent.socket | grep -o "/run.*")
+```
+
+##### 4. SSH will now automatically use your device key in all terminals.


### PR DESCRIPTION
Arch Linux uses systemd to manage the GPG and SSH agent by default, so I adapted that to use trezor-agent.  I didn't want the overhead of a process per terminal and I think process management is a bit simpler this way.