### PR TITLE
trezor: Use composite transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See SatoshiLabs' blog posts about this feature:
 - [TREZOR Firmware 1.3.6 — GPG Signing, SSH Login Updates and Advanced Transaction Features for Segwit](https://medium.com/@satoshilabs/trezor-firmware-1-3-6-20a7df6e692)
 - [TREZOR Firmware 1.4.0 — GPG decryption support](https://www.reddit.com/r/TREZOR/comments/50h8r9/new_trezor_firmware_fidou2f_and_initial_ethereum/d7420q7/)
 
-Currently [TREZOR](https://trezor.io/), [Keepkey](https://www.keepkey.com/), and [Ledger Nano S](https://www.ledgerwallet.com/products/ledger-nano-s) are supported.
+Currently [TREZOR One](https://trezor.io/), [TREZOR Model T](https://trezor.io/), [Keepkey](https://www.keepkey.com/), and [Ledger Nano S](https://www.ledgerwallet.com/products/ledger-nano-s) are supported.
 
 ## Documentation
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -12,11 +12,11 @@ You can install them on these distributions as follows:
 
 ##### Debian
 
-    $ apt install python-pip python-dev python-tk libusb-1.0-0-dev libudev-dev
+    $ apt-get install python3-pip python3-dev python3-tk libusb-1.0-0-dev libudev-dev
 
 ##### Fedora/RedHat
 
-    $ yum install python-pip python-devel python-tk libusb-devel libudev-devel \
+    $ yum install python3-pip python3-devel python3-tk libusb-devel libudev-devel \
                   gcc redhat-rpm-config
 
 ##### OpenSUSE
@@ -55,14 +55,14 @@ gpg (GnuPG) 2.1.15
 3. Then, install the latest [trezor_agent](https://pypi.python.org/pypi/trezor_agent) package:
 
     ```
-    $ pip install trezor_agent
+    $ pip3 install trezor_agent
     ```
 
     Or, directly from the latest source code:
 
     ```
     $ git clone https://github.com/romanz/trezor-agent
-    $ pip install --user -e trezor-agent/agents/trezor
+    $ pip3 install --user -e trezor-agent/agents/trezor
     ```
 
     Read [these instructions](https://github.com/romanz/python-trezor#pin-entering) on how to enter your PIN with the PIN entry.
@@ -77,14 +77,14 @@ gpg (GnuPG) 2.1.15
 Then, install the latest [keepkey_agent](https://pypi.python.org/pypi/keepkey_agent) package:
 
     ```
-    $ pip install keepkey_agent
+    $ pip3 install keepkey_agent
     ```
 
     Or, directly from the latest source code:
 
     ```
     $ git clone https://github.com/romanz/trezor-agent
-    $ pip install --user -e trezor-agent/agents/keepkey
+    $ pip3 install --user -e trezor-agent/agents/keepkey
     ```
 
 # 4. Install the Ledger Nano S agent
@@ -97,14 +97,14 @@ Then, install the latest [keepkey_agent](https://pypi.python.org/pypi/keepkey_ag
 3. Then, install the latest [ledger_agent](https://pypi.python.org/pypi/ledger_agent) package:
 
     ```
-    $ pip install ledger_agent
+    $ pip3 install ledger_agent
     ```
 
     Or, directly from the latest source code:
 
     ```
     $ git clone https://github.com/romanz/trezor-agent
-    $ pip install --user -e trezor-agent/agents/ledger
+    $ pip3 install --user -e trezor-agent/agents/ledger
     ```
 
 # 5. Installation Troubleshooting

--- a/libagent/device/trezor_defs.py
+++ b/libagent/device/trezor_defs.py
@@ -5,6 +5,4 @@
 from trezorlib.client import CallException, PinException
 from trezorlib.client import TrezorClient as Client
 from trezorlib.messages import IdentityType, PassphraseAck, PinMatrixAck
-from trezorlib.transport_bridge import BridgeTransport
-from trezorlib.transport_hid import HidTransport
-from trezorlib.transport_udp import UdpTransport
+from trezorlib.device import TrezorDevice


### PR DESCRIPTION
Hello Roman,

this pull request introduces composite transport (implemented as TrezorDevice object), which can newly detect and connect to any Trezor device using various transports, including new Model T and even desktop emulator running over UDP.

TrezorDevice currently implements UDP transport (for emulator), Bridge transport (for any hardware), WebUSB transport (Model T) and HID transport (Trezor One).

Also, I modified installation instructions to use Python3, as Python2 is no longer officially maintained for python-trezor (although we'll accept pull requests fixing Python2 compatibility).

Also please note there's known bug in Model T for ed25519 (getpublickey returns invalid pubkey, which is correctly catched by trezor-agent). It will be fixed in upcoming firmware update.

Cheers!
Marek