### PR TITLE
Add docs to show using the gpg agent with systemd; set PATH for ssh unit

### DIFF
--- a/doc/README-GPG.md
+++ b/doc/README-GPG.md
@@ -181,3 +181,54 @@ Press <enter> to keep the current choice[*], or type selection number: 0
 ### Sign and decrypt email
 
 Follow [these instructions](enigmail.md) to set up Enigmail in Thunderbird.
+
+### Start the agent as a systemd unit
+
+##### 1. Create these files in `~/.config/systemd/user`
+
+Replace `trezor` with `keepkey` or `ledger` as required.
+
+###### `trezor-gpg-agent.service`
+
+````
+[Unit]
+Description=trezor-gpg-agent
+Requires=trezor-gpg-agent.socket
+
+[Service]
+Type=Simple
+Environment="GNUPGHOME=%h/.gnupg/trezor"
+Environment="PATH=/bin:/usr/bin:/usr/local/bin:%h/.local/bin"
+ExecStart=/usr/bin/trezor-gpg-agent -vv
+````
+
+If you've installed `trezor-agent` locally you may have to change the path in `ExecStart=`.
+
+###### `trezor-gpg-agent.socket`
+
+````
+[Unit]
+Description=trezor-gpg-agent socket
+
+[Socket]
+ListenStream=%t/gnupg/S.gpg-agent
+FileDescriptorName=std
+SocketMode=0600
+DirectoryMode=0700
+
+[Install]
+WantedBy=sockets.target
+````
+
+##### 2. Stop trezor-gpg-agent if it's already running
+
+```
+killall trezor-gpg-agent
+```
+
+##### 3. Run
+
+```
+systemctl --user start trezor-gpg-agent.service trezor-gpg-agent.socket
+systemctl --user enable trezor-gpg-agent.socket
+```

--- a/doc/README-SSH.md
+++ b/doc/README-SSH.md
@@ -113,6 +113,7 @@ Requires=trezor-ssh-agent.socket
 
 [Service]
 Type=Simple
+Environment="DISPLAY=:0"
 Environment="GNUPGHOME=%h/.gnupg/trezor"
 Environment="PATH=/bin:/usr/bin:/usr/local/bin:%h/.local/bin"
 ExecStart=/usr/bin/trezor-agent --foreground --sock-path %t/trezor-agent/S.ssh IDENTITY

--- a/doc/README-SSH.md
+++ b/doc/README-SSH.md
@@ -113,8 +113,12 @@ Requires=trezor-ssh-agent.socket
 
 [Service]
 Type=Simple
+Environment="GNUPGHOME=%h/.gnupg/trezor"
+Environment="PATH=/bin:/usr/bin:/usr/local/bin:%h/.local/bin"
 ExecStart=/usr/bin/trezor-agent --foreground --sock-path %t/trezor-agent/S.ssh IDENTITY
 ````
+
+If you've installed `trezor-agent` locally you may have to change the path in `ExecStart=`.
 
 Replace `IDENTITY` with the identity you used when exporting the public key.
 


### PR DESCRIPTION
This is mostly for consistency with the SSH agent usage.

I also changed the SSH agent systemd unit to add `Environment=` since I think it may be be necessary for the new pinentry stuff.