### PR TITLE
Fix crash on Python2

### DIFF
--- a/libagent/device/ui.py
+++ b/libagent/device/ui.py
@@ -82,7 +82,7 @@ class UnexpectedError(Exception):
 def expect(p, prefixes):
     """Read a line and return it without required prefix."""
     resp = p.stdout.readline()
-    log.debug('%s -> %r', p.args, resp)
+    log.debug('%s -> %r', getattr(p, 'args', '?'), resp)
     for prefix in prefixes:
         if resp.startswith(prefix):
             return resp[len(prefix):]


### PR DESCRIPTION
The subprocess.Popen object does not have a member variable `args` under Python2.