### PR TITLE
trezor: use TREZOR_PATH environment variable to specify device path

### DIFF
--- a/doc/README-SSH.md
+++ b/doc/README-SSH.md
@@ -123,7 +123,7 @@ Description=trezor-agent SSH agent
 Requires=trezor-ssh-agent.socket
 
 [Service]
-Type=Simple
+Type=simple
 Environment="DISPLAY=:0"
 Environment="PATH=/bin:/usr/bin:/usr/local/bin:%h/.local/bin"
 ExecStart=/usr/bin/trezor-agent --foreground --sock-path %t/trezor-agent/S.ssh IDENTITY
@@ -132,6 +132,14 @@ ExecStart=/usr/bin/trezor-agent --foreground --sock-path %t/trezor-agent/S.ssh I
 If you've installed `trezor-agent` locally you may have to change the path in `ExecStart=`.
 
 Replace `IDENTITY` with the identity you used when exporting the public key.
+
+If you have multiple Trezors connected, you can select which one to use via a `TREZOR_PATH`
+environment variable. Use `trezorctl list` to find the correct path. Then add it
+to the agent with the following line:
+````
+Environment="TREZOR_PATH=<your path here>"
+````
+Note that USB paths depend on the _USB port_ which you use.
 
 ###### `trezor-ssh-agent.socket`
 

--- a/libagent/device/trezor.py
+++ b/libagent/device/trezor.py
@@ -106,13 +106,13 @@ class Trezor(interface.Device):
 
     def connect(self):
         """Enumerate and connect to the first available interface."""
-        transports = self._defs.enumerate_transports()
-        if not transports:
+        transport = self._defs.find_device()
+        if not transport:
             raise interface.NotFoundError('{} not connected'.format(self))
 
-        log.debug('transports: %s', transports)
+        log.debug('using transport: %s', transport)
         for _ in range(5):  # Retry a few times in case of PIN failures
-            connection = self._defs.Client(transport=transports[0],
+            connection = self._defs.Client(transport=transport,
                                            state=self.__class__.cached_state)
             self._override_pin_handler(connection)
             self._override_passphrase_handler(connection)

--- a/libagent/device/trezor_defs.py
+++ b/libagent/device/trezor_defs.py
@@ -1,13 +1,27 @@
 """TREZOR-related definitions."""
 
 # pylint: disable=unused-import,import-error
+import os
+import logging
 
 from trezorlib.client import CallException, PinException
 from trezorlib.client import TrezorClient as Client
 from trezorlib.messages import IdentityType, PassphraseAck, PinMatrixAck, PassphraseStateAck
-from trezorlib.device import TrezorDevice
+
+try:
+    from trezorlib.transport import get_transport
+except ImportError:
+    from trezorlib.device import TrezorDevice
+    get_transport = TrezorDevice.find_by_path
+
+log = logging.getLogger(__name__)
 
 
-def enumerate_transports():
-    """Returns all available transports."""
-    return TrezorDevice.enumerate()
+def find_device():
+    """Selects a transport based on `TREZOR_PATH` env variable.
+    If unset, picks first connected device.
+    """
+    try:
+        return get_transport(os.environ.get("TREZOR_PATH"))
+    except Exception as e:
+        log.debug("Failed to find a Trezor device: %s", e)


### PR DESCRIPTION
Useful when you have multiple Trezors connected :)

I'm not sure if this is the best way to implement it, but it's probably the most straightforward one. Also this is a minority usecase.