### PR TITLE
fix import error with CallException

### DIFF
--- a/libagent/device/trezor_defs.py
+++ b/libagent/device/trezor_defs.py
@@ -4,7 +4,8 @@
 import os
 import logging
 
-from trezorlib.client import CallException, PinException
+from trezorlib.client import PinException
+from trezorlib.tools import CallException
 from trezorlib.client import TrezorClient as Client
 from trezorlib.messages import IdentityType, PassphraseAck, PinMatrixAck, PassphraseStateAck
 


### PR DESCRIPTION
Using the HEAD version of python-trezor gives the following error when using trezor-agent:
```
File "/home/user/.pyenv/versions/3.6.3/envs/trezor3.new/lib/python3.6/site-packages/libagent/device/interface.py", line 118, in __enter__                                 
    self.conn = self.connect()                                                                                                                                               
  File "/home/user/.pyenv/versions/3.6.3/envs/trezor3.new/lib/python3.6/site-packages/libagent/device/trezor.py", line 109, in connect                                      
    transports = self._defs.enumerate_transports()                                                                                                                           
  File "/home/user/.pyenv/versions/3.6.3/envs/trezor3.new/lib/python3.6/site-packages/libagent/device/trezor.py", line 25, in _defs                                         
    from . import trezor_defs                                                                                                                                                
  File "/home/user/.pyenv/versions/3.6.3/envs/trezor3.new/lib/python3.6/site-packages/libagent/device/trezor_defs.py", line 5, in <module>                                  
    from trezorlib.client import CallException, PinException                                                                                                                 
ImportError: cannot import name 'CallException'

```

This PR fixes it.