### PR TITLE
Add missing pre-reqs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ setup(
         'libagent.ssh'
     ],
     install_requires=[
+        'docutils>=0.14',
+        'wheel>=0.32.3',
         'backports.shutil_which>=3.5.1',
         'ConfigArgParse>=0.12.1',
         'python-daemon>=2.1.2',


### PR DESCRIPTION
Attempting to install 0.10.2 from PyPI failed because docutils and wheel were not already installed.