### PR TITLE
Trezor 0.11

### DIFF
--- a/agents/trezor/setup.py
+++ b/agents/trezor/setup.py
@@ -11,7 +11,7 @@ setup(
     scripts=['trezor_agent.py'],
     install_requires=[
         'libagent>=0.11.2',
-        'trezor[hidapi]>=0.9.0'
+        'trezor[hidapi]>=0.10.1'
     ],
     platforms=['POSIX'],
     classifiers=[

--- a/libagent/device/fake_device.py
+++ b/libagent/device/fake_device.py
@@ -39,10 +39,6 @@ class FakeDevice(interface.Device):
         self.vk = self.sk.get_verifying_key()
         return self
 
-    def close(self):
-        """Close connection."""
-        self.conn = None
-
     def pubkey(self, identity, ecdh=False):
         """Return public key."""
         _verify_support(identity)

--- a/libagent/device/interface.py
+++ b/libagent/device/interface.py
@@ -114,6 +114,11 @@ class Device:
         raise NotImplementedError()
 
     def close(self):
+        """Close connection to device.
+
+        By default, close the underlying connection. Overriding classes
+        can perform their own cleanup.
+        """
         self.conn.close()
 
     def __enter__(self):

--- a/libagent/device/interface.py
+++ b/libagent/device/interface.py
@@ -113,6 +113,9 @@ class Device:
         """Connect to device, otherwise raise NotFoundError."""
         raise NotImplementedError()
 
+    def close(self):
+        self.conn.close()
+
     def __enter__(self):
         """Allow usage as context manager."""
         self.conn = self.connect()
@@ -121,7 +124,7 @@ class Device:
     def __exit__(self, *args):
         """Close and mark as disconnected."""
         try:
-            self.conn.close()
+            self.close()
         except Exception as e:  # pylint: disable=broad-except
             log.exception('close failed: %s', e)
         self.conn = None

--- a/libagent/device/ui.py
+++ b/libagent/device/ui.py
@@ -24,7 +24,7 @@ class UI:
         self.options_getter = create_default_options_getter()
         self.device_name = device_type.__name__
 
-    def get_pin(self, name=None):
+    def get_pin(self, _code=None):
         """Ask the user for (scrambled) PIN."""
         description = (
             'Use the numeric keypad to describe number positions.\n'
@@ -33,20 +33,24 @@ class UI:
             '    4 5 6\n'
             '    1 2 3')
         return interact(
-            title='{} PIN'.format(name or self.device_name),
+            title='{} PIN'.format(self.device_name),
             prompt='PIN:',
             description=description,
             binary=self.pin_entry_binary,
             options=self.options_getter())
 
-    def get_passphrase(self, name=None):
+    def get_passphrase(self):
         """Ask the user for passphrase."""
         return interact(
-            title='{} passphrase'.format(name or self.device_name),
+            title='{} passphrase'.format(self.device_name),
             prompt='Passphrase:',
             description=None,
             binary=self.passphrase_entry_binary,
             options=self.options_getter())
+
+    def button_request(self, _code=None):
+        # XXX: show notification to the user?
+        pass
 
 
 def create_default_options_getter():

--- a/libagent/device/ui.py
+++ b/libagent/device/ui.py
@@ -49,8 +49,8 @@ class UI:
             options=self.options_getter())
 
     def button_request(self, _code=None):
+        """Called by TrezorClient when device interaction is required."""
         # XXX: show notification to the user?
-        pass
 
 
 def create_default_options_getter():


### PR DESCRIPTION
resolves #277 

had to bump version requirement for python-trezor to 0.10.1 because otherwise the `[hidapi]` requirement would break. We could keep 0.9 compatibility if we could get around that. But there's probably no point in doing it.

We could *also* bump all the way to 0.11 and drop the compatibility wrappers