### PR TITLE
support trezorlib 0.12

### DIFF
--- a/agents/trezor/setup.py
+++ b/agents/trezor/setup.py
@@ -11,7 +11,7 @@ setup(
     scripts=['trezor_agent.py'],
     install_requires=[
         'libagent>=0.13.0',
-        'trezor[hidapi]>=0.11.0'
+        'trezor[hidapi]>=0.12.0,<0.13'
     ],
     platforms=['POSIX'],
     classifiers=[
@@ -22,8 +22,6 @@ setup(
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
         'Operating System :: POSIX',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/libagent/device/trezor_defs.py
+++ b/libagent/device/trezor_defs.py
@@ -8,12 +8,12 @@ import mnemonic
 import semver
 import trezorlib
 
-from trezorlib.client import TrezorClient as Client
+from trezorlib.client import TrezorClient as Client, PASSPHRASE_TEST_PATH
 from trezorlib.exceptions import TrezorFailure, PinException
 from trezorlib.transport import get_transport
 from trezorlib.messages import IdentityType
 
-from trezorlib.btc import get_public_node
+from trezorlib.btc import get_address, get_public_node
 from trezorlib.misc import sign_identity, get_ecdh_session_key
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
fixes #319 

also removes declared support for python < 3.5, which is not supported by trezorlib

not sure if you like how `ui.py` changes are handled?

i tried to keep the trezorlib import optional, but didn't want to go through `trezor_defs`

also on TT passphrase is automatically entered on device, unless envvar `TREZOR_PASSPHRASE` is set, which, again, I'm not sure if that is what you want.
the alternative might be something like:
* prompting before passphrase entry
* always prompt unless an envvar is set
* never prompt unless an envvar is set to prompt
* etc.?