### PR TITLE
Quote PATH when writing agent invocation script

### DIFF
--- a/libagent/gpg/__init__.py
+++ b/libagent/gpg/__init__.py
@@ -143,7 +143,7 @@ def run_init(device_type, args):
     # Prepare GPG agent invocation script (to pass the PATH from environment).
     with open(os.path.join(homedir, 'run-agent.sh'), 'w') as f:
         f.write(r"""#!/bin/sh
-export PATH={0}
+export PATH="{0}"
 {1} \
 -vv \
 --pin-entry-binary={pin_entry_binary} \


### PR DESCRIPTION
If the PATH contains spaces, the agent invocation script will break at runtime. This quotes the variable so that spaces don't break the script.