### PR TITLE
Enable cross-certificaton on the encryption subkey. 

### DIFF
--- a/libagent/gpg/encode.py
+++ b/libagent/gpg/encode.py
@@ -57,21 +57,18 @@ def create_subkey(primary_bytes, subkey, signer_func, secret_bytes=b''):
 
     data_to_sign = primary['_to_hash'] + subkey.data_to_hash()
 
-    if subkey.ecdh:
-        embedded_sig = None
-    else:
-        # Primary Key Binding Signature
-        hashed_subpackets = [
-            protocol.subpacket_time(subkey.created)]  # signature time
-        unhashed_subpackets = [
-            protocol.subpacket(16, subkey.key_id())]  # issuer key id
-        embedded_sig = protocol.make_signature(
-            signer_func=signer_func,
-            data_to_sign=data_to_sign,
-            public_algo=subkey.algo_id,
-            sig_type=0x19,
-            hashed_subpackets=hashed_subpackets,
-            unhashed_subpackets=unhashed_subpackets)
+    # Primary Key Binding Signature
+    hashed_subpackets = [
+        protocol.subpacket_time(subkey.created)]  # signature time
+    unhashed_subpackets = [
+        protocol.subpacket(16, subkey.key_id())]  # issuer key id
+    embedded_sig = protocol.make_signature(
+        signer_func=signer_func,
+        data_to_sign=data_to_sign,
+        public_algo=subkey.algo_id,
+        sig_type=0x19,
+        hashed_subpackets=hashed_subpackets,
+        unhashed_subpackets=unhashed_subpackets)
 
     # Subkey Binding Signature
 


### PR DESCRIPTION
This PR addresses [this](https://github.com/romanz/trezor-agent/issues/356) issue, by enabling cross-certification of the encryption subkey.