### PR TITLE
Run CI also on Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Use quotes around the Python version (otherwise 3.10 converts to 3.1): https://github.com/actions/setup-python/issues/249#issuecomment-934299359