### PR TITLE
Allow signing arbitrary SSH messages

### DIFF
--- a/libagent/ssh/client.py
+++ b/libagent/ssh/client.py
@@ -31,17 +31,23 @@ class Client:
 
     def sign_ssh_challenge(self, blob, identity):
         """Sign given blob using a private key on the device."""
-        msg = _parse_ssh_blob(blob)
-        log.debug('%s: user %r via %r (%r)',
-                  msg['conn'], msg['user'], msg['auth'], msg['key_type'])
-        log.debug('nonce: %r', msg['nonce'])
-        fp = msg['public_key']['fingerprint']
-        log.debug('fingerprint: %s', fp)
-        log.debug('hidden challenge size: %d bytes', len(blob))
+        try:
+            msg = _parse_ssh_blob(blob)
+            log.debug('parsed')
+            log.debug('%s: user %r via %r (%r)',
+                      msg['conn'], msg['user'], msg['auth'], msg['key_type'])
+            log.debug('nonce: %r', msg['nonce'])
+            fp = msg['public_key']['fingerprint']
+            log.debug('fingerprint: %s', fp)
+            log.debug('hidden challenge size: %d bytes', len(blob))
 
-        log.info('please confirm user "%s" login to "%s" using %s...',
-                 msg['user'].decode('ascii'), identity.to_string(),
-                 self.device)
+            log.info('please confirm user "%s" login to "%s" using %s...',
+                     msg['user'].decode('ascii'), identity.to_string(),
+                     self.device)
+        except:
+            log.info('please confirm signing for "%s" using %s...',
+                     identity.to_string(),
+                     self.device)
 
         with self.device:
             return self.device.sign(blob=blob, identity=identity)


### PR DESCRIPTION
Hi,

Thanks for making trezor-agent!

Currently the Trezor SSH Agent closes the client connection if the payload of a signing request fails to parse as a `SSH2_MSG_USERAUTH_REQUEST` data structure (and/or a SSH Signature blob in #370).
But the SSH agent protocol, and Trezor, allows signing arbitrary messages. This PR enables SSH signature requests to be passed through to Trezor even if they do not match the known formats. This change enables signing for other applications, such as using [JSON Web Signatures](https://tools.ietf.org/html/rfc7515) and [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/).