### PR TITLE
Add Support for NIST256 ssh-certificates

### DIFF
--- a/libagent/formats.py
+++ b/libagent/formats.py
@@ -25,8 +25,10 @@ SSH_NIST256_DER_OCTET = b'\x04'
 SSH_NIST256_KEY_PREFIX = b'ecdsa-sha2-'
 SSH_NIST256_CURVE_NAME = b'nistp256'
 SSH_NIST256_KEY_TYPE = SSH_NIST256_KEY_PREFIX + SSH_NIST256_CURVE_NAME
+SSH_NIST256_CERT_POSTFIX = b'-cert-v01@openssh.com'
+SSH_NIST256_CERT_TYPE = SSH_NIST256_KEY_TYPE + SSH_NIST256_CERT_POSTFIX
 SSH_ED25519_KEY_TYPE = b'ssh-ed25519'
-SUPPORTED_KEY_TYPES = {SSH_NIST256_KEY_TYPE, SSH_ED25519_KEY_TYPE}
+SUPPORTED_KEY_TYPES = {SSH_NIST256_KEY_TYPE, SSH_NIST256_CERT_TYPE, SSH_ED25519_KEY_TYPE}
 
 hashfunc = hashlib.sha256
 
@@ -57,10 +59,27 @@ def parse_pubkey(blob):
 
     result = {'blob': blob, 'type': key_type, 'fingerprint': fp}
 
-    if key_type == SSH_NIST256_KEY_TYPE:
+    if key_type == SSH_NIST256_KEY_TYPE or key_type == SSH_NIST256_CERT_TYPE:
+        if key_type == SSH_NIST256_CERT_TYPE:
+            _nonce = util.read_frame(s)
+
         curve_name = util.read_frame(s)
         log.debug('curve name: %s', curve_name)
         point = util.read_frame(s)
+
+        if key_type == SSH_NIST256_CERT_TYPE:
+            _serial_number = util.recv(s, '>Q')
+            _type = util.recv(s, '>L')
+            _key_id = util.read_frame(s)
+            _valid_principals = util.read_frame(s)
+            _valid_after = util.recv(s, '>Q')
+            _valid_before = util.recv(s, '>Q')
+            _critical_options = util.read_frame(s)
+            _extensions = util.read_frame(s)
+            _reserved = util.read_frame(s)
+            _signature_key = util.read_frame(s)
+            _signature = util.read_frame(s)
+
         assert s.read() == b''
         _type, point = point[:1], point[1:]
         assert _type == SSH_NIST256_DER_OCTET

--- a/libagent/tests/test_formats.py
+++ b/libagent/tests/test_formats.py
@@ -23,6 +23,26 @@ _public_key = (
     'home\n'
 )
 
+_public_key_cert = (
+	'ecdsa-sha2-nistp256-cert-v01@openssh.com '
+	'AAAAKGVjZHNhLXNoYTItbmlzdHAyNTYtY2VydC12MDFAb3B'
+	'lbnNzaC5jb20AAAAgohlAP8H3LPYWz3+w/E+RGDxG6tNAEE'
+	'3Ao9Z6Pc66khEAAAAIbmlzdHAyNTYAAABBBGI2zqveJSB+g'
+	'eQEWG46OvGs2h3+0qu7tIdsH8WylrV19vttd7GR5rKvTWJt'
+	'8b9ErthmnFALelAFKOB/u50jsukAAAAAAAAAFQAAAAEAAAA'
+	'IdW5pdFRlc3QAAAAIAAAABHVzZXIAAAAAAAAAAP////////'
+	'//AAAAAAAAAIIAAAAVcGVybWl0LVgxMS1mb3J3YXJkaW5nA'
+	'AAAAAAAABdwZXJtaXQtYWdlbnQtZm9yd2FyZGluZwAAAAAA'
+	'AAAWcGVybWl0LXBvcnQtZm9yd2FyZGluZwAAAAAAAAAKcGV'
+	'ybWl0LXB0eQAAAAAAAAAOcGVybWl0LXVzZXItcmMAAAAAAA'
+	'AAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgf9gyPrF24CLZc'
+	'0rHoZuI1+yjBFWt66G8oUmm20yRO8IAAABTAAAAC3NzaC1l'
+	'ZDI1NTE5AAAAQCEgVgsR7fSgcTxuAWqMW4h42y7pt1BAKR4'
+	'HTRg178tl7Vx8WoRtQcNirX9eggBcTA+5ILWmeY3uDN+soW'
+	't7fwk= '
+	'home\n'
+)
+
 
 def test_parse_public_key():
     key = formats.import_public_key(_public_key)
@@ -32,6 +52,15 @@ def test_parse_public_key():
     assert key['curve'] == 'nist256p1'
     assert key['fingerprint'] == '4b:19:bc:0f:c8:7e:dc:fa:1a:e3:c2:ff:6f:e0:80:a2'  # nopep8
     assert key['type'] == b'ecdsa-sha2-nistp256'
+
+def test_parse_public_key_cert()
+    key = formats.import_public_key(_public_key_cert)
+    assert key['name'] == b'home'
+    assert key['point'] == _point
+
+    assert key['curve'] == 'nist256p1'
+    assert key['fingerprint'] == '4b:19:bc:0f:c8:7e:dc:fa:1a:e3:c2:ff:6f:e0:80:a2'  # nopep8
+    assert key['type'] == b'ecdsa-sha2-nistp256-cert-v01@openssh.com'
 
 
 def test_decompress():


### PR DESCRIPTION
This should enable the usage of SSH-certificates using the NIST256 curve. By Testing this I found out that the payload to be signed is too big for the Trezor One but it is usable using a Trezor Model T.

This should also closes #372