### PR TITLE
fix: provide buf argument to unsupported_extension function

### DIFF
--- a/libagent/ssh/protocol.py
+++ b/libagent/ssh/protocol.py
@@ -167,6 +167,6 @@ class Handler:
         return util.frame(code, data)
 
 
-def _unsupported_extension():
+def _unsupported_extension(buf):
     code = util.pack('B', msg_code('SSH_AGENT_EXTENSION_FAILURE'))
     return util.frame(code)


### PR DESCRIPTION
Tried newest master, and with this addition it works with new ssh servers.
Without this PR it failed, because the function is being called with arg: `method(buf=buf)`.
Not sure if you have planned something else, in that case just close this pr.