### PR TITLE
Add simulator device

### DIFF
--- a/agents/simulator/setup.py
+++ b/agents/simulator/setup.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+from setuptools import setup
+
+setup(
+    name='simulator_agent',
+    version='0.0.1',
+    description='Using a simulation of a hardware device as SSH/GPG/age agent',
+    author='Roman Zeyde',
+    author_email='dev@romanzey.de',
+    url='http://github.com/romanz/trezor-agent',
+    scripts=['simulator_agent.py'],
+    install_requires=[
+        'libagent>=0.14.0'
+    ],
+    platforms=['POSIX', 'win32'],
+    classifiers=[
+        'Environment :: Console',
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Information Technology',
+        'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
+        'Operating System :: POSIX',
+        'Operating System :: Microsoft :: Windows',
+        'Programming Language :: Python :: 3 :: Only',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: System :: Networking',
+        'Topic :: Communications',
+        'Topic :: Security',
+        'Topic :: Utilities',
+    ],
+    entry_points={'console_scripts': [
+        'simulator-agent = simulator_agent:ssh_agent',
+        'simulator-gpg = simulator_agent:gpg_tool',
+        'simulator-gpg-agent = simulator_agent:gpg_agent',
+        'simulator-signify = simulator_agent:signify_tool',
+        'age-plugin-simulator = simulator_agent:age_tool',
+    ]},
+)

--- a/agents/simulator/simulator_agent.py
+++ b/agents/simulator/simulator_agent.py
@@ -1,0 +1,8 @@
+from libagent import age, signify, gpg, ssh
+from libagent.device.simulator import Simulator as DeviceType
+
+age_tool = lambda: age.main(DeviceType)
+ssh_agent = lambda: ssh.main(DeviceType)
+gpg_tool = lambda: gpg.main(DeviceType)
+gpg_agent = lambda: gpg.run_agent(DeviceType)
+signify_tool = lambda: signify.main(DeviceType)

--- a/libagent/age/__init__.py
+++ b/libagent/age/__init__.py
@@ -43,7 +43,7 @@ def run_pubkey(device_type, args):
                 'so please note that the API and features may '
                 'change without backwards compatibility!')
 
-    c = client.Client(device=device_type())
+    c = client.Client(device=device_type(args))
     pubkey = c.pubkey(identity=client.create_identity(args.identity), ecdh=True)
     recipient = bech32_encode(prefix="age", data=pubkey)
     print(f"# recipient: {recipient}")
@@ -89,7 +89,7 @@ def decrypt(key, encrypted):
 def run_decrypt(device_type, args):
     """Unlock hardware device (for future interaction)."""
     # pylint: disable=too-many-locals
-    c = client.Client(device=device_type())
+    c = client.Client(device=device_type(args))
 
     lines = (line.strip() for line in sys.stdin)  # strip whitespace
     lines = (line for line in lines if line)  # skip empty lines
@@ -148,6 +148,7 @@ def _handle_single_file(file_index, stanzas, identities, c):
 def main(device_type):
     """Parse command-line arguments."""
     p = argparse.ArgumentParser()
+    device_type.setup_arg_parser(p)
 
     agent_package = device_type.package_name()
     resources_map = {r.key: r for r in pkg_resources.require(agent_package)}

--- a/libagent/device/fake_device.py
+++ b/libagent/device/fake_device.py
@@ -26,6 +26,10 @@ class FakeDevice(interface.Device):
         """Python package name."""
         return 'fake-device-agent'
 
+    @classmethod
+    def setup_arg_parser(cls, parser):
+        """Add device-specific parameters to the argument parser."""
+
     def connect(self):
         """Return "dummy" connection."""
         log.critical('NEVER USE THIS CODE FOR REAL-LIFE USE-CASES!!!')

--- a/libagent/device/interface.py
+++ b/libagent/device/interface.py
@@ -105,9 +105,10 @@ class Identity:
 class Device:
     """Abstract cryptographic hardware device interface."""
 
-    def __init__(self):
+    def __init__(self, args):
         """C-tor."""
         self.conn = None
+        self.args = args
 
     def connect(self):
         """Connect to device, otherwise raise NotFoundError."""
@@ -142,9 +143,21 @@ class Device:
         """Sign given blob and return the signature (as bytes)."""
         raise NotImplementedError()
 
+    def sign_with_pubkey(self, identity, blob):
+        """Sign given blob and return the signature (as bytes)."""
+        return (self.sign(identity, blob),
+                formats.compress_pubkey(self.pubkey(identity, ecdh=False),
+                                        identity.get_curve_name(False)))
+
     def ecdh(self, identity, pubkey):
         """Get shared session key using Elliptic Curve Diffie-Hellman."""
         raise NotImplementedError()
+
+    def ecdh_with_pubkey(self, identity, pubkey):
+        """Get shared session key using Elliptic Curve Diffie-Hellman."""
+        return (self.ecdh(identity, pubkey),
+                formats.compress_pubkey(self.pubkey(identity, ecdh=True),
+                                        identity.get_curve_name(True))[1:])
 
     def __str__(self):
         """Human-readable representation."""

--- a/libagent/device/jade.py
+++ b/libagent/device/jade.py
@@ -30,6 +30,10 @@ class BlockstreamJade(interface.Device):
         """Python package name (at PyPI)."""
         return 'jade-agent'
 
+    @classmethod
+    def setup_arg_parser(cls, parser):
+        """Add device-specific parameters to the argument parser."""
+
     def connect(self):
         """Connect to the first matching device."""
         # pylint: disable=import-error

--- a/libagent/device/keepkey.py
+++ b/libagent/device/keepkey.py
@@ -25,6 +25,10 @@ class KeepKey(trezor.Trezor):
         """Python package name (at PyPI)."""
         return 'keepkey-agent'
 
+    @classmethod
+    def setup_arg_parser(cls, parser):
+        """Add device-specific parameters to the argument parser."""
+
     @property
     def _defs(self):
         from . import keepkey_defs

--- a/libagent/device/ledger.py
+++ b/libagent/device/ledger.py
@@ -60,6 +60,10 @@ class LedgerNanoS(interface.Device):
         """Python package name (at PyPI)."""
         return 'ledger-agent'
 
+    @classmethod
+    def setup_arg_parser(cls, parser):
+        """Add device-specific parameters to the argument parser."""
+
     def connect(self):
         """Enumerate and connect to the first USB HID interface."""
         try:

--- a/libagent/device/onlykey.py
+++ b/libagent/device/onlykey.py
@@ -28,6 +28,10 @@ class OnlyKey(interface.Device):
         """Python package name (at PyPI)."""
         return 'onlykey-agent'
 
+    @classmethod
+    def setup_arg_parser(cls, parser):
+        """Add device-specific parameters to the argument parser."""
+
     @property
     def _defs(self):
         from . import onlykey_defs

--- a/libagent/device/simulator.py
+++ b/libagent/device/simulator.py
@@ -1,0 +1,246 @@
+"""Simulator for a hardware wallet device."""
+
+import hashlib
+import hmac
+import logging
+
+import ecdsa
+import ecdsa.ecdh
+import nacl.bindings
+import nacl.public
+import nacl.signing
+from mnemonic import Mnemonic
+
+from .. import formats, util
+from . import interface
+
+log = logging.getLogger(__name__)
+
+
+class _CurveNist256p1:
+    @classmethod
+    def get_seed(cls):
+        return b'Nist256p1 seed'
+
+    @classmethod
+    def get_order(cls):
+        return ecdsa.curves.NIST256p.order
+
+    def __init__(self, key_bytes):
+        self.signing_key = ecdsa.SigningKey.from_string(
+            key_bytes,
+            curve=ecdsa.curves.NIST256p,
+            hashfunc=hashlib.sha256
+        )
+
+    def get_public_key(self):
+        return self.PublicKey(self.signing_key.verifying_key)
+
+    def sign(self, data):
+        return self.signing_key.sign_digest_deterministic(digest=data,
+                                                          hashfunc=hashlib.sha256)
+
+    def ecdh(self, public_key):
+        peer = formats.decompress_pubkey(public_key, formats.CURVE_NIST256)
+        return b'\x04' + (
+            peer.pubkey.point
+            * self.signing_key.privkey.secret_multiplier
+        ).to_bytes('raw')
+
+    class PublicKey:
+        def __init__(self, verifying_key):
+            self.verifying_key = verifying_key
+
+        def get_bytes(self):
+            return self.verifying_key.to_string('compressed')
+
+        def get_raw(self):
+            return self.verifying_key
+
+
+class _Ed25519:
+    @classmethod
+    def get_seed(cls):
+        return b'ed25519 seed'
+
+    @classmethod
+    def get_order(cls):
+        return None
+
+    def __init__(self, key_bytes):
+        self.signing_key = nacl.signing.SigningKey(key_bytes)
+
+    def get_public_key(self):
+        return self.PublicKey(self.signing_key.verify_key)
+
+    def sign(self, data):
+        return self.signing_key.sign(data).signature
+
+    def ecdh(self, public_key):
+        assert len(public_key) == 33
+        return b'\x04' + nacl.bindings.crypto_scalarmult(
+            bytes(self.signing_key.to_curve25519_private_key()), public_key)
+
+    class PublicKey:
+        def __init__(self, verify_key):
+            self.verify_key = verify_key
+
+        def get_bytes(self):
+            return bytes(self.verify_key)
+
+        def get_raw(self):
+            return self.verify_key
+
+
+class _Curve25519:
+    @classmethod
+    def get_seed(cls):
+        return b'curve25519 seed'
+
+    @classmethod
+    def get_order(cls):
+        return None
+
+    def __init__(self, key_bytes):
+        self.private_key = nacl.public.PrivateKey(key_bytes)
+
+    def get_public_key(self):
+        return self.PublicKey(nacl.signing.VerifyKey(bytes(self.private_key.public_key)))
+
+    def sign(self, data):
+        # Signing not supported
+        raise NotImplementedError()
+
+    def ecdh(self, public_key):
+        assert len(public_key) == 33
+        return b'\x04' + nacl.bindings.crypto_scalarmult(bytes(self.private_key), public_key[1:])
+
+    class PublicKey:
+        def __init__(self, verify_key):
+            self.verify_key = verify_key
+
+        def get_bytes(self):
+            return bytes(self.verify_key)
+
+        def get_raw(self):
+            return self.verify_key
+
+
+SUPPORTED_CURVES = {
+    formats.CURVE_NIST256: _CurveNist256p1,
+    formats.CURVE_ED25519: _Ed25519,
+    formats.ECDH_CURVE25519: _Curve25519,
+}
+
+
+def _derive_key(seed, identity, ecdh):
+    curve = SUPPORTED_CURVES[identity.get_curve_name(ecdh)]
+    curve_order = curve.get_order()
+    curve_seed = curve.get_seed()
+    address = identity.get_bip32_address(ecdh)
+
+    digest = hmac.new(curve_seed, seed, hashlib.sha512).digest()
+    privkey_bytes = digest[:32]
+    privkey = util.bytes2num(privkey_bytes)
+    if curve_order is not None:
+        while privkey == 0 or privkey >= curve_order:
+            digest = hmac.new(curve_seed, digest, hashlib.sha512).digest()
+            privkey = util.bytes2num(digest[:32])
+    chain = digest[32:]
+
+    for index in address:
+        index_bytes = index.to_bytes(4, 'big')
+        if index >= 0x80000000:
+            data = b'\x00' + privkey_bytes
+        else:
+            data = curve(privkey_bytes).get_public_key().get_bytes()
+        if curve_order is None:
+            data += index_bytes
+            digest = hmac.new(chain, data, hashlib.sha512).digest()
+            privkey_bytes = digest[:32]
+            privkey = util.bytes2num(privkey_bytes)
+            chain = digest[32:]
+        else:
+            while True:
+                data += index_bytes
+                digest = hmac.new(chain, data, hashlib.sha512).digest()
+
+                child_privkey = util.bytes2num(digest[:32])
+                if child_privkey < curve_order:
+                    child_privkey = (child_privkey + privkey) % curve_order
+                    if child_privkey != 0:
+                        privkey = child_privkey
+                        privkey_bytes = util.num2bytes(privkey, size=32)
+                        chain = digest[32:]
+                        break
+
+                data = b'\x01' + digest[32:]
+
+    return curve(privkey_bytes)
+
+
+class Simulator(interface.Device):
+    """Simulator for a hardware wallet device."""
+
+    @classmethod
+    def package_name(cls):
+        """Python package name."""
+        return 'simulator-agent'
+
+    @classmethod
+    def setup_arg_parser(cls, parser):
+        """Add device-specific parameters to the argument parser."""
+        log.critical('This simulator is NOT a replacement for a real hardware device.')
+        log.critical('There are a thousand ways a hacker could steal the mnemonic you enter.')
+        log.critical('Only use for testing, or for assets you can afford to lose.')
+        parser.add_argument('--mnemonic', default=None,
+                            help='the mnemonic phrase to generate the master seed')
+        parser.add_argument('--passphrase', default=None,
+                            help='the passphrase to a hidden wallet')
+        parser.add_argument('--no-passphrase', default=False, action='store_true',
+                            help='use a blank passphrase')
+
+    ui = None  # can be overridden by device's users
+
+    def __init__(self, args):
+        """C-tor."""
+        super().__init__(args)
+        self.seed = None
+
+    def connect(self):
+        """Request mnemonic from user, after giving ample warning."""
+        mnemonic = self.args.mnemonic
+        passphrase = self.args.passphrase
+        if mnemonic is None:
+            mnemonic = self.ui.get_passphrase('Enter your mnemonic:',
+                                              description='WARNING: Do NOT use the '
+                                              'simulator with a real '
+                                              'wallet\'s mnemonic!\n'
+                                              'It is NOT secure, and your '
+                                              'mnemonic WILL be stolen!\n')
+        if passphrase is None and self.args.no_passphrase:
+            passphrase = ''
+        if passphrase is None:
+            passphrase = (self.ui.get_passphrase('Enter your passphrase',
+                                                 description='Leave blank for the default wallet'))
+
+        self.seed = Mnemonic.to_seed(mnemonic, passphrase)
+
+    def close(self):
+        """Close the device."""
+
+    def pubkey(self, identity, ecdh=False):
+        """Get public key (as bytes)."""
+        return _derive_key(self.seed, identity, ecdh).get_public_key().get_raw()
+
+    def sign(self, identity, blob):
+        """Sign given blob and return the signature (as bytes)."""
+        if identity.identity_dict['proto'] in {'ssh'}:
+            digest = hashlib.sha256(blob).digest()
+        else:
+            digest = blob
+        return _derive_key(self.seed, identity, False).sign(digest)
+
+    def ecdh(self, identity, pubkey):
+        """Get shared session key using Elliptic Curve Diffie-Hellman."""
+        return _derive_key(self.seed, identity, True).ecdh(pubkey)

--- a/libagent/device/trezor.py
+++ b/libagent/device/trezor.py
@@ -19,6 +19,10 @@ class Trezor(interface.Device):
         """Python package name (at PyPI)."""
         return 'trezor-agent'
 
+    @classmethod
+    def setup_arg_parser(cls, parser):
+        """Add device-specific parameters to the argument parser."""
+
     @property
     def _defs(self):
         from . import trezor_defs

--- a/libagent/device/ui.py
+++ b/libagent/device/ui.py
@@ -49,11 +49,11 @@ class UI:
             binary=self.pin_entry_binary,
             options=self.options_getter())
 
-    def get_passphrase(self, prompt='Passphrase:', available_on_device=False):
+    def get_passphrase(self, prompt='Passphrase:', description=None, available_on_device=False):
         """Ask the user for passphrase."""
         passphrase = None
         if self.cached_passphrase_ack:
-            passphrase = self.cached_passphrase_ack.get()
+            passphrase = self.cached_passphrase_ack.get(prompt)
         if passphrase is None:
             env_passphrase = os.environ.get("TREZOR_PASSPHRASE")
             if env_passphrase is not None:
@@ -64,11 +64,11 @@ class UI:
                 passphrase = interact(
                     title='{} passphrase'.format(self.device_name),
                     prompt=prompt,
-                    description=None,
+                    description=description,
                     binary=self.passphrase_entry_binary,
                     options=self.options_getter())
         if self.cached_passphrase_ack:
-            self.cached_passphrase_ack.set(passphrase)
+            self.cached_passphrase_ack.set(prompt, passphrase)
         return passphrase
 
     def button_request(self, _code=None):

--- a/libagent/formats.py
+++ b/libagent/formats.py
@@ -185,6 +185,30 @@ def decompress_pubkey(pubkey, curve_name):
     return vk
 
 
+def compress_pubkey(pubkey, curve_name):
+    """
+    Transform a public key into a serialized blob.
+
+    Reverse of decompress_pubkey.
+    """
+    if isinstance(pubkey, nacl.signing.VerifyKey):
+        compressed = pubkey.encode(encoder=nacl.encoding.RawEncoder)
+        if len(compressed) == 32:
+            if curve_name == ECDH_CURVE25519:
+                compressed = b'\x40' + compressed
+            else:
+                compressed = b'\x00' + compressed
+        return compressed
+
+    if isinstance(pubkey, ecdsa.keys.VerifyingKey):
+        return pubkey.to_string('compressed')
+
+    if isinstance(pubkey, (bytes, bytearray)):
+        return pubkey
+
+    raise TypeError('unsupported {!r}'.format(pubkey))
+
+
 def serialize_verifying_key(vk):
     """
     Serialize a public key into SSH format (for exporting to text format).

--- a/libagent/ssh/__init__.py
+++ b/libagent/ssh/__init__.py
@@ -80,6 +80,7 @@ def create_agent_parser(device_type):
               'doc/README-SSH.md for usage examples.')
     p = configargparse.ArgParser(default_config_files=['~/.ssh/agent.config'],
                                  epilog=epilog)
+    device_type.setup_arg_parser(p)
     p.add_argument('-v', '--verbose', default=0, action='count')
 
     agent_package = device_type.package_name()
@@ -325,7 +326,7 @@ def main(device_type):
     device_type.ui = device.ui.UI(device_type=device_type, config=vars(args))
 
     conn = JustInTimeConnection(
-        conn_factory=lambda: client.Client(device_type()),
+        conn_factory=lambda: client.Client(device_type(args)),
         identities=identities, public_keys=public_keys)
 
     sock_path = _get_sock_path(args)

--- a/libagent/ssh/tests/test_client.py
+++ b/libagent/ssh/tests/test_client.py
@@ -52,7 +52,7 @@ SIG = (b'R\x19T\xf2\x84$\xef#\x0e\xee\x04X\xc6\xc3\x99T`\xd1\xd8\xf7!'
 def test_ssh_agent():
     identity = device.interface.Identity(identity_str='localhost:22',
                                          curve_name=CURVE)
-    c = client.Client(device=MockDevice())
+    c = client.Client(device=MockDevice(object()))
     assert c.export_public_keys([identity]) == [PUBKEY_TEXT]
     signature = c.sign_ssh_challenge(blob=BLOB, identity=identity)
 

--- a/libagent/tests/test_util.py
+++ b/libagent/tests/test_util.py
@@ -125,22 +125,23 @@ def test_assuan_serialize():
 
 def test_cache():
     timer = mock.Mock(side_effect=range(7))
-    c = util.ExpiringCache(seconds=2, timer=timer)  # t=0
-    assert c.get() is None                          # t=1
+    c = util.ExpiringCache(seconds=2, timer=timer)
+    c.set('not_the_key', 'unused')                  # t=0
+    assert c.get('key') is None                     # t=1
     obj = 'foo'
-    c.set(obj)                                      # t=2
-    assert c.get() is obj                           # t=3
-    assert c.get() is obj                           # t=4
-    assert c.get() is None                          # t=5
-    assert c.get() is None                          # t=6
+    c.set('key', obj)                               # t=2
+    assert c.get('key') is obj                      # t=3
+    assert c.get('key') is obj                      # t=4
+    assert c.get('key') is None                     # t=5
+    assert c.get('key') is None                     # t=6
 
 
 def test_cache_inf():
     timer = mock.Mock(side_effect=range(6))
     c = util.ExpiringCache(seconds=float('inf'), timer=timer)
     obj = 'foo'
-    c.set(obj)
-    assert c.get() is obj
-    assert c.get() is obj
-    assert c.get() is obj
-    assert c.get() is obj
+    c.set('key', obj)
+    assert c.get('key') is obj
+    assert c.get('key') is obj
+    assert c.get('key') is obj
+    assert c.get('key') is obj

--- a/libagent/util.py
+++ b/libagent/util.py
@@ -290,16 +290,17 @@ class ExpiringCache:
         """C-tor."""
         self.duration = seconds
         self.timer = timer
-        self.value = None
-        self.set(None)
+        self.values = {}
 
-    def get(self):
+    def get(self, key):
         """Returns existing value, or None if deadline has expired."""
-        if self.timer() > self.deadline:
-            self.value = None
-        return self.value
+        curtime = self.timer()
+        self.values = {k: v for k, v in self.values.items() if curtime <= v[0]}
+        return self.values.get(key, (None, None))[1]
 
-    def set(self, value):
+    def set(self, key, value):
         """Set new value and reset the deadline for expiration."""
-        self.deadline = self.timer() + self.duration
-        self.value = value
+        self.values[key] = (
+            self.timer() + self.duration,
+            value
+        )


### PR DESCRIPTION
This simulator is fully compatible with a Trezor device, but takes the mnemonic/passphrase via commandline or pinentry. Can be useful for testing, try-before-you-buy for hardware devices (in the context of trezor-agent only), and CI. For the latter, is an improvement over FakeDevice, in that it can produce different keys based on derivation path, so it can be used to test things like original vs foreign key detection based on derivation from user id, which FakeDevice can't do.

And it's also good for producing doc examples that aren't based on anyone's real key.

Also adds the ability to have per-device command line arguments for all tools. Currently used for simulator mnemonics. But can also be used for e.g. Trezor multi-device selection.