### PR TITLE
Fix AssertionError on decryption whenever there is another ECC key in the keychain

### DIFF
--- a/libagent/gpg/agent.py
+++ b/libagent/gpg/agent.py
@@ -171,8 +171,10 @@ class Handler:
         pubkey = protocol.PublicKey(
             curve_name=curve_name, created=pubkey_dict['created'],
             verifying_key=verifying_key, ecdh=ecdh)
-        assert pubkey.key_id() == pubkey_dict['key_id']
-        assert pubkey.keygrip() == keygrip_bytes
+
+        if (pubkey.key_id() != pubkey_dict['key_id'] or pubkey.keygrip() != keygrip_bytes):
+            raise KeyError('{} keygrip does not correspond to key on device.'.format(keygrip))
+
         return identity
 
     def pksign(self, conn):


### PR DESCRIPTION
Whenever there are other public keys in the GPG keychain with the ECC alogrithm, decryption is not possible. 

How to reproduce:

Short:
Suppose our trezor-key has the uuid: 'trezor'. We create another public key called 'A' and encrypt a file with both keys.
Decryption is not possible.

Long:
1. Generate second key with the following properties: ECC and ECC (encryption) - nistp256
`gpg --full-generate-key --expert
   (9) ECC and ECC
   (3) NIST P-256
Key is valid for? (0) 0
Real name: A
`
2. Delete secret key for key 'A'
`gpg --delete-secret-key 'A'`
3. Encrypt a test file with both keys
`gpg -e -r A -r trezor test`
4. Restart trezor gpg agent
5. Try to decrypt
`gpg -d test.gpg`

Result: There is an AssertionError:
 File "/home/user/projects/trezor-agent/libagent/gpg/agent.py", line 174, in get_identity
    assert pubkey.key_id() == pubkey_dict['key_id']
AssertionError

This is the case, because all compatible keys in the keychain are being tried and when the key is not the same with the key on the HW device an Assertion error is thrown.

Fix by: Ignore keys which do not correspond to key on device instead of throwing an Assertion Error
