### PR TITLE
replace pkg_resources for python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/agents/fake/setup.py
+++ b/agents/fake/setup.py
@@ -11,6 +11,7 @@ setup(
     author='Roman Zeyde',
     author_email='dev@romanzey.de',
     url='http://github.com/romanz/trezor-agent',
+    python_requires='>=3.8',
     scripts=['fake_device_agent.py'],
     install_requires=[
         'libagent>=0.9.0',

--- a/agents/jade/setup.py
+++ b/agents/jade/setup.py
@@ -8,6 +8,7 @@ setup(
     author='Jamie C. Driver',
     author_email='jamie@blockstream.com',
     url='http://github.com/romanz/trezor-agent',
+    python_requires='>=3.8',
     scripts=['jade_agent.py'],
     install_requires=[
         'libagent>=0.14.5',

--- a/agents/keepkey/setup.py
+++ b/agents/keepkey/setup.py
@@ -8,6 +8,7 @@ setup(
     author='Roman Zeyde',
     author_email='dev@romanzey.de',
     url='http://github.com/romanz/trezor-agent',
+    python_requires='>=3.8',
     scripts=['keepkey_agent.py'],
     install_requires=[
         'libagent>=0.9.0',

--- a/agents/ledger/setup.py
+++ b/agents/ledger/setup.py
@@ -8,6 +8,7 @@ setup(
     author='Roman Zeyde',
     author_email='dev@romanzey.de',
     url='http://github.com/romanz/trezor-agent',
+    python_requires='>=3.8',
     scripts=['ledger_agent.py'],
     install_requires=[
         'libagent>=0.9.0',

--- a/agents/onlykey/setup.py
+++ b/agents/onlykey/setup.py
@@ -8,6 +8,7 @@ setup(
     author='CryptoTrust',
     author_email='t@crp.to',
     url='http://github.com/trustcrypto/onlykey-agent',
+    python_requires='>=3.8',
     scripts=['onlykey_agent.py'],
     install_requires=[
         'libagent>=0.14.2',

--- a/agents/trezor/setup.py
+++ b/agents/trezor/setup.py
@@ -8,6 +8,7 @@ setup(
     author='Roman Zeyde',
     author_email='dev@romanzey.de',
     url='http://github.com/romanz/trezor-agent',
+    python_requires='>=3.8',
     scripts=['trezor_agent.py'],
     install_requires=[
         'libagent>=0.14.0',

--- a/libagent/age/__init__.py
+++ b/libagent/age/__init__.py
@@ -13,9 +13,9 @@ import io
 import logging
 import os
 import sys
+from importlib import metadata
 
 import bech32
-import pkg_resources
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 
@@ -150,9 +150,8 @@ def main(device_type):
     p = argparse.ArgumentParser()
 
     agent_package = device_type.package_name()
-    resources_map = {r.key: r for r in pkg_resources.require(agent_package)}
-    resources = [resources_map[agent_package], resources_map['libagent']]
-    versions = '\n'.join('{}={}'.format(r.key, r.version) for r in resources)
+    resources = [metadata.distribution(agent_package), metadata.distribution('libagent')]
+    versions = '\n'.join('{}={}'.format(r.metadata['Name'], r.version) for r in resources)
     p.add_argument('--version', help='print the version info',
                    action='version', version=versions)
 

--- a/libagent/gpg/__init__.py
+++ b/libagent/gpg/__init__.py
@@ -17,13 +17,13 @@ import re
 import stat
 import subprocess
 import sys
+from importlib import metadata
 
 try:
     # TODO: Not supported on Windows. Use daemoniker instead?
     import daemon
 except ImportError:
     daemon = None
-import pkg_resources
 import semver
 
 from .. import device, formats, server, util
@@ -308,9 +308,8 @@ def main(device_type):
     parser = argparse.ArgumentParser(epilog=epilog)
 
     agent_package = device_type.package_name()
-    resources_map = {r.key: r for r in pkg_resources.require(agent_package)}
-    resources = [resources_map[agent_package], resources_map['libagent']]
-    versions = '\n'.join('{}={}'.format(r.key, r.version) for r in resources)
+    resources = [metadata.distribution(agent_package), metadata.distribution('libagent')]
+    versions = '\n'.join('{}={}'.format(r.metadata['Name'], r.version) for r in resources)
     parser.add_argument('--version', help='print the version info',
                         action='version', version=versions)
 

--- a/libagent/ssh/__init__.py
+++ b/libagent/ssh/__init__.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+from importlib import metadata
 
 import configargparse
 
@@ -21,7 +22,6 @@ try:
     import daemon
 except ImportError:
     daemon = None
-import pkg_resources
 
 from .. import device, formats, server, util
 from . import client, protocol
@@ -83,9 +83,8 @@ def create_agent_parser(device_type):
     p.add_argument('-v', '--verbose', default=0, action='count')
 
     agent_package = device_type.package_name()
-    resources_map = {r.key: r for r in pkg_resources.require(agent_package)}
-    resources = [resources_map[agent_package], resources_map['libagent']]
-    versions = '\n'.join('{}={}'.format(r.key, r.version) for r in resources)
+    resources = [metadata.distribution(agent_package), metadata.distribution('libagent')]
+    versions = '\n'.join('{}={}'.format(r.metadata['Name'], r.version) for r in resources)
     p.add_argument('--version', help='print the version info',
                    action='version', version=versions)
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     author='Roman Zeyde',
     author_email='dev@romanzey.de',
     url='http://github.com/romanz/trezor-agent',
+    python_requires='>=3.8',
     packages=[
         'libagent',
         'libagent.age',


### PR DESCRIPTION
Python 3.12 has removed bundled `setuptools` (aka `pkg_resources`): https://docs.python.org/3.12/whatsnew/3.12.html#removed

Also bumps to python 3.8+ (since 3.7 is unsupported and would require a backport of `importlib.metadata`)
