### PR TITLE
setup: remove dep on backport of shutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         'docutils>=0.14',
         'python-daemon>=2.3.0',
         'wheel>=0.32.3',
-        'backports.shutil_which>=3.5.1',
         'ConfigArgParse>=0.12.1',
         'python-daemon>=2.1.2',
         'ecdsa>=0.13',


### PR DESCRIPTION
This backport was needed only for Python 2 (the shutil.which module was backported from Python 3 to 2). In Python 3, the module is imported from the built-in standard library.

This resolves issues with packaging for distributions, since that backported package doesn't exist.ror if missing.

See libagent/util.py:241:
```
    try:
        # For Python 3
        from shutil import which as _which
    except ImportError:
        # For Python 2
        from backports.shutil_which import which as _which
```
If Python 2 is still supported, then the dependency in setup.py would need to be made conditional on Python version. I am assuming Python 2 is not actually supported, so I just removed the dependency altogether. This try catch in util.py could also be removed, if Python 2 is not actually supported.