### PR TITLE
rework signify arguments for compatiblity with signify and minisign

### DIFF
--- a/agents/trezor/setup.py
+++ b/agents/trezor/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='trezor_agent',
-    version='0.12.0',
+    version='0.12.1',
     description='Using Trezor as hardware SSH/GPG agent',
     author='Roman Zeyde',
     author_email='dev@romanzey.de',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='libagent',
-    version='0.15.0',
+    version='0.15.1',
     description='Using hardware wallets as SSH/GPG/age agent',
     author='Roman Zeyde',
     author_email='dev@romanzey.de',


### PR DESCRIPTION
Both signify and minisign have a concept of untrusted comment, which if signing by default seems to point to the pubkey. If available, the option for untrusted comment only ever seems to be -c.

Only minisign seems to have a concept of a trusted comment and the option for a trusted comment is -t

This commit makes the trusted comment optional
(defaults to off, previously defaulted to time.asctime()). This removes the unneeded signing and prompt round for those who do not need or use the trusted comment section.

This commit also brings the `trezor-signify` command line closer to the minisign and signify tools, which unfortunately seems to be a breaking change, but the previous state seemed to be more messy.

This fixes #502 