### PR TITLE
libagent: Add USB IDs for Jade Plus

### DIFF
--- a/libagent/device/jade.py
+++ b/libagent/device/jade.py
@@ -22,7 +22,11 @@ class BlockstreamJade(interface.Device):
     """Connection to Blockstream Jade device."""
 
     MIN_SUPPORTED_FW_VERSION = semver.VersionInfo(0, 1, 33)
-    DEVICE_IDS = [(0x10c4, 0xea60), (0x1a86, 0x55d4)]
+    DEVICE_IDS = [
+        (0x10c4, 0xea60),  # Jade 1.0
+        (0x1a86, 0x55d4),  # Jade 1.1
+        (0x303a, 0x4001),  # Jade 2 (Plus)
+    ]
     connection = None
 
     @classmethod


### PR DESCRIPTION
While trying to use the agent with a Jade Plus I got some errors, like:
```
    result = self.conn.get_identity_pubkey(identity_string, curve_name, key_type) 
AttributeError: 'NoneType' object has no attribute 'get_identity_pubkey'
```

After some tinkering and confirming with someone else, the issue was that [`DEVICE_IDS`](https://github.com/romanz/trezor-agent/blob/master/libagent/device/jade.py#L25) was only expecting the Jade 1.0 and Jade 1.1 IDs, not the Jade Plus. 