### PR TITLE
ssh-agent: support systemd socket activation (LISTEN_FDS)

### DIFF
--- a/libagent/server.py
+++ b/libagent/server.py
@@ -14,6 +14,9 @@ if sys.platform == 'win32':
 
 log = logging.getLogger(__name__)
 
+# The first file descriptor passed by systemd socket activation (SD_LISTEN_FDS_START).
+SD_LISTEN_FDS_START = 3
+
 
 def remove_file(path, remove=os.remove, exists=os.path.exists):
     """Remove file, and raise OSError if still exists."""
@@ -82,6 +85,64 @@ class FDServer:
 def unix_domain_socket_server_from_fd(fd):
     """Build UDS-based socket server from a file descriptor."""
     yield FDServer(fd)
+
+
+def socket_activation_fd(environ=None, pid=None):
+    """Return the listening fd passed by systemd socket activation, else None.
+
+    Implements the ``sd_listen_fds(3)`` protocol: activation is honored only when
+    ``LISTEN_PID`` names this process and ``LISTEN_FDS`` passes at least one
+    socket; the first one is ``SD_LISTEN_FDS_START``. The activation variables
+    are removed from the environment (as with ``unset_environment=1``) so that
+    any subprocess the agent later spawns does not re-interpret them.
+    """
+    if environ is None:
+        environ = os.environ
+    if pid is None:
+        pid = os.getpid()
+
+    listen_pid = environ.get('LISTEN_PID')
+    listen_fds = environ.get('LISTEN_FDS')
+    if listen_pid is None or listen_fds is None:
+        return None
+
+    # Consume the activation variables regardless of validity.
+    for var in ('LISTEN_PID', 'LISTEN_FDS', 'LISTEN_FDNAMES'):
+        environ.pop(var, None)
+
+    if listen_pid != str(pid):
+        log.warning('LISTEN_PID=%s does not match our pid %d; '
+                    'ignoring socket activation', listen_pid, pid)
+        return None
+    try:
+        count = int(listen_fds)
+    except ValueError:
+        log.warning('LISTEN_FDS=%r is not an integer; ignoring', listen_fds)
+        return None
+    if count < 1:
+        log.warning('LISTEN_FDS=%d passed no sockets; ignoring', count)
+        return None
+    if count > 1:
+        log.warning('LISTEN_FDS=%d: only the first passed socket is used', count)
+    return SD_LISTEN_FDS_START
+
+
+@contextlib.contextmanager
+def unix_domain_socket_server_from_systemd(fd):
+    """Adopt a systemd-activated *listening* UNIX-domain socket.
+
+    Unlike :func:`unix_domain_socket_server`, the socket is already bound and
+    listening (systemd owns it), so it is neither bound nor unlinked here: the
+    socket file's lifetime belongs to the ``.socket`` unit.
+    """
+    log.debug('adopting systemd-activated socket on fd %d', fd)
+    # Don't leak the inherited fd into any subprocess the agent spawns.
+    os.set_inheritable(fd, False)
+    server = socket.fromfd(fd, socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        yield server
+    finally:
+        server.close()
 
 
 def handle_connection(conn, handler, mutex):

--- a/libagent/ssh/__init__.py
+++ b/libagent/ssh/__init__.py
@@ -139,13 +139,23 @@ def serve(handler, sock_path, timeout=UNIX_SOCKET_TIMEOUT):
 
     If no connection is made during the specified timeout,
     retry until the context is over.
+
+    Under systemd socket activation (``LISTEN_FDS``), adopt the inherited
+    listening socket instead of binding ``sock_path``; ``sock_path`` is then
+    only used to advertise ``SSH_AUTH_SOCK`` and should match the unit's
+    ``ListenStream=``.
     """
     ssh_version = subprocess.check_output(['ssh', '-V'],
                                           stderr=subprocess.STDOUT)
     log.debug('local SSH version: %r', ssh_version)
     environ = {'SSH_AUTH_SOCK': sock_path, 'SSH_AGENT_PID': str(os.getpid())}
     device_mutex = threading.Lock()
-    with server.unix_domain_socket_server(sock_path) as sock:
+    listen_fd = server.socket_activation_fd()
+    if listen_fd is not None:
+        sock_server = server.unix_domain_socket_server_from_systemd(listen_fd)
+    else:
+        sock_server = server.unix_domain_socket_server(sock_path)
+    with sock_server as sock:
         sock.settimeout(timeout)
         quit_event = threading.Event()
         handle_conn = functools.partial(server.handle_connection,

--- a/libagent/tests/test_server.py
+++ b/libagent/tests/test_server.py
@@ -18,6 +18,56 @@ def test_socket():
     assert not os.path.isfile(path)
 
 
+def test_socket_activation_fd():
+    # Not activated: no environment variables present.
+    assert server.socket_activation_fd(environ={}, pid=1234) is None
+
+    # Activated for this process: the first passed fd is adopted, and the
+    # activation variables are consumed.
+    env = {'LISTEN_PID': '1234', 'LISTEN_FDS': '1', 'LISTEN_FDNAMES': 'conn'}
+    assert server.socket_activation_fd(environ=env, pid=1234) == \
+        server.SD_LISTEN_FDS_START
+    assert not env  # activation variables were consumed
+
+    # More than one passed socket: still adopt the first one.
+    env = {'LISTEN_PID': '1234', 'LISTEN_FDS': '3'}
+    assert server.socket_activation_fd(environ=env, pid=1234) == \
+        server.SD_LISTEN_FDS_START
+    assert not env  # activation variables were consumed
+
+    # Activation aimed at another process is ignored (but still consumed).
+    env = {'LISTEN_PID': '5678', 'LISTEN_FDS': '1'}
+    assert server.socket_activation_fd(environ=env, pid=1234) is None
+    assert not env  # activation variables were consumed
+
+    # Malformed / empty fd counts are ignored.
+    assert server.socket_activation_fd(
+        environ={'LISTEN_PID': '1234', 'LISTEN_FDS': 'x'}, pid=1234) is None
+    assert server.socket_activation_fd(
+        environ={'LISTEN_PID': '1234', 'LISTEN_FDS': '0'}, pid=1234) is None
+
+
+def test_socket_server_from_systemd():
+    path = tempfile.mktemp()
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(path)
+    listener.listen(1)
+    try:
+        with server.unix_domain_socket_server_from_systemd(listener.fileno()) as sock:
+            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            client.connect(path)
+            conn, _ = sock.accept()
+            client.sendall(b'ping')
+            assert conn.recv(4) == b'ping'
+            conn.close()
+            client.close()
+        # The socket file belongs to systemd: it must NOT be unlinked.
+        assert os.path.exists(path)
+    finally:
+        listener.close()
+        server.remove_file(path)
+
+
 class FakeSocket:
 
     def __init__(self, data=b''):


### PR DESCRIPTION
I run `trezor-agent` as a systemd **user** service and wanted it to be *socket-activated*: systemd owns the listening socket, so `SSH_AUTH_SOCK` is valid the moment I log in, no agent process needs to run while the socket is idle, and the agent starts on the first SSH connection.

Today this can't work cleanly. The agent always binds (and `unlink`s) its own socket path, so when systemd has already bound the socket and handed it to us on fd 3, the agent unlinks systemd's socket and binds a new one over it — which defeats activation and is racy.

This PR makes the agent honor the `sd_listen_fds(3)` protocol. When started with socket activation (`LISTEN_PID` names our process and `LISTEN_FDS >= 1`), the agent adopts the inherited listening socket (`SD_LISTEN_FDS_START`, fd 3) instead of binding `--sock-path`. The socket file belongs to systemd, so it is never bound or unlinked; the activation variables are consumed so spawned subprocesses don't re-interpret them, and the inherited fd is marked non-inheritable.

When not socket-activated, behavior is unchanged.

To use it, point the `.socket` unit's `ListenStream=` at the same path you pass to `--sock-path` and run the agent with `--foreground`.

### Changes

- `server.py`: `socket_activation_fd()` (the `sd_listen_fds` env check, with the variables consumed) and `unix_domain_socket_server_from_systemd()` (adopt the listening fd without binding/unlinking).
- `ssh/__init__.py`: `serve()` adopts the inherited socket when activated.
- Tests for the activation env protocol (including the multi-fd and wrong-PID/malformed cases) and for adopting a real listening socket without unlinking it.

**Compatibility:** no change when `LISTEN_FDS` is unset.
