### PR TITLE
ssh: default -e/--ecdsa-curve-name to ed25519

### DIFF
--- a/libagent/ssh/__init__.py
+++ b/libagent/ssh/__init__.py
@@ -90,7 +90,7 @@ def create_agent_parser(device_type):
 
     curve_names = ', '.join(sorted(formats.SUPPORTED_CURVES))
     p.add_argument('-e', '--ecdsa-curve-name', metavar='CURVE',
-                   default=formats.CURVE_NIST256,
+                   default=formats.CURVE_ED25519,
                    help='specify ECDSA curve name: ' + curve_names)
     p.add_argument('--timeout',
                    default=UNIX_SOCKET_TIMEOUT, type=float,

--- a/libagent/ssh/tests/test_init.py
+++ b/libagent/ssh/tests/test_init.py
@@ -1,0 +1,20 @@
+import mock
+
+from ... import formats
+from .. import create_agent_parser
+
+
+def _parser():
+    device_type = mock.Mock()
+    device_type.package_name.return_value = 'libagent'
+    return create_agent_parser(device_type=device_type)
+
+
+def test_default_curve_is_ed25519():
+    args = _parser().parse_args(['ssh://localhost'])
+    assert args.ecdsa_curve_name == formats.CURVE_ED25519
+
+
+def test_curve_can_be_overridden():
+    args = _parser().parse_args(['-e', formats.CURVE_NIST256, 'ssh://localhost'])
+    assert args.ecdsa_curve_name == formats.CURVE_NIST256


### PR DESCRIPTION
The default SSH curve is `nist256p1`. ed25519 is the modern default for SSH keys basically everywhere else, and the `nist256p1` default is an easy footgun: the curve is part of the key derivation, so forgetting `-e ed25519` silently derives a **different** key than the ed25519 one most people expect — followed by the usual "my key changed" / "the server rejects me" confusion.

This flips the default of `-e/--ecdsa-curve-name` to `ed25519` (one line).

**Compatibility:** the curve is recorded per identity, so this only affects identities given on the command line. Previously exported public keys and identities loaded from a config file keep their recorded curve, and `-e nist256p1` remains available. No migration is required.

Includes a small test asserting the new default and that `-e nist256p1` still overrides it.
