### PR TITLE
doc: document --sock-path and ship systemd unit examples

### DIFF
--- a/contrib/systemd/README.md
+++ b/contrib/systemd/README.md
@@ -1,0 +1,34 @@
+# systemd user units for `trezor-agent`
+
+Example units that run `trezor-agent` as a resident, socket-activated SSH agent
+for your user. systemd holds the listening socket and starts the agent on the
+first connection, so `SSH_AUTH_SOCK` is valid as soon as you log in and no agent
+process needs to run while the socket is idle.
+
+## Install
+
+```
+mkdir -p ~/.config/systemd/user
+cp trezor-ssh-agent.socket trezor-ssh-agent.service ~/.config/systemd/user/
+```
+
+Edit `~/.config/systemd/user/trezor-ssh-agent.service` and replace `IDENTITY`
+with your identity (e.g. `user@example.com`) or the path to a file listing your
+exported public keys. Adjust the `trezor-agent` path in `ExecStart=` if it is
+not installed in `/usr/bin`.
+
+Then enable and start it:
+
+```
+systemctl --user enable --now trezor-ssh-agent.socket
+```
+
+Finally, point SSH at the socket by adding this to your `~/.bashrc` (or
+equivalent):
+
+```bash
+export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/trezor-agent/S.ssh"
+```
+
+See [`../../doc/README-SSH.md`](../../doc/README-SSH.md) for details and the
+`--sock-path` option.

--- a/contrib/systemd/trezor-ssh-agent.service
+++ b/contrib/systemd/trezor-ssh-agent.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=trezor-agent SSH agent
+Requires=trezor-ssh-agent.socket
+After=trezor-ssh-agent.socket
+
+[Service]
+Type=simple
+Restart=always
+# A graphical PIN / passphrase prompt needs access to your display.
+Environment="DISPLAY=:0"
+Environment="PATH=/bin:/usr/bin:/usr/local/bin:%h/.local/bin"
+# Replace IDENTITY with the identity you used to export your public key, e.g.
+# user@example.com. It can also be a path (starting with /) to a file listing
+# one exported public key per line, which is the convenient way to serve
+# several keys/hosts from a single agent.
+#
+# --sock-path must match the .socket unit's ListenStream=. If trezor-agent is
+# installed somewhere other than /usr/bin, adjust the path below.
+ExecStart=/usr/bin/trezor-agent --foreground --sock-path %t/trezor-agent/S.ssh IDENTITY
+
+[Install]
+Also=trezor-ssh-agent.socket

--- a/contrib/systemd/trezor-ssh-agent.socket
+++ b/contrib/systemd/trezor-ssh-agent.socket
@@ -1,0 +1,14 @@
+[Unit]
+Description=trezor-agent SSH agent socket
+
+[Socket]
+# This path is what SSH_AUTH_SOCK should point at (see the .service unit and
+# doc/README-SSH.md). %t expands to $XDG_RUNTIME_DIR (e.g. /run/user/1000).
+ListenStream=%t/trezor-agent/S.ssh
+FileDescriptorName=ssh
+Service=trezor-ssh-agent.service
+SocketMode=0600
+DirectoryMode=0700
+
+[Install]
+WantedBy=sockets.target

--- a/doc/README-SSH.md
+++ b/doc/README-SSH.md
@@ -150,7 +150,32 @@ For more details, see the following great blog post: https://calebhearth.com/sig
 		allowedSignersFile = /home/user/Code/test-git-ssh-sig/.git/allowed-signers
 
 
+### Run a resident agent with a stable socket (`--sock-path`)
+
+By default `trezor-agent` puts its agent socket at a random path
+(`tempfile.mktemp(...)`) and only prints it when started with `-d`/`--daemonize`.
+That is fine for one-shot use, but a long-running ("resident") agent needs a
+*stable* socket path so that `SSH_AUTH_SOCK` can be pointed at it in advance —
+otherwise the socket appears to be "missing" because its path is unpredictable.
+
+Use `--sock-path` to pick that path and `--foreground` to keep the agent
+running:
+
+```
+$ trezor-agent --foreground --sock-path "$XDG_RUNTIME_DIR/trezor-agent.sock" identity@myhost &
+$ export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/trezor-agent.sock"
+$ ssh identity@myhost   # uses the resident agent
+```
+
+`$XDG_RUNTIME_DIR` (typically `/run/user/$UID`) is a good location: it is
+user-private and cleaned up on logout. The next section automates this with
+systemd.
+
 ### Start the agent as a systemd unit
+
+Ready-to-edit copies of the unit files below are shipped in
+[`contrib/systemd/`](../contrib/systemd/) — see that directory's `README.md` for
+a one-shot install. The inline copies follow.
 
 ##### 1. Create these files in `~/.config/systemd/user`
 


### PR DESCRIPTION
`--sock-path` is used in the systemd example in `README-SSH.md` but is never explained on its own. By default the agent socket is created at a random `tempfile.mktemp()` path (printed only with `-d`), which is exactly why the socket looks "missing" when you expect a stable one — a recurring source of confusion.

This PR:

- documents `--sock-path` and the `--foreground` + `--sock-path` pattern for running a resident agent with a stable socket (and recommends `$XDG_RUNTIME_DIR`);
- ships ready-to-edit `trezor-ssh-agent.socket` / `trezor-ssh-agent.service` units under `contrib/systemd/` (with a short install `README.md`), and references them from the systemd section, so users can install them directly instead of copy-pasting from the docs.

Docs/examples only — no code or behavior change.
