### PR TITLE
device: add --close-after-idle to release the device between operations

### DIFF
--- a/libagent/device/interface.py
+++ b/libagent/device/interface.py
@@ -105,6 +105,14 @@ class Identity:
 class Device:
     """Abstract cryptographic hardware device interface."""
 
+    # Release a cached device session when the agent is otherwise idle, so the
+    # device is free for other applications between operations. In seconds:
+    #   None  -> keep the session for the agent's whole lifetime (default).
+    #   0     -> release after every operation.
+    #   N > 0 -> release after N seconds of inactivity.
+    # Honored by backends that cache a session across operations.
+    close_after_idle = None
+
     def __init__(self):
         """C-tor."""
         self.conn = None

--- a/libagent/device/trezor.py
+++ b/libagent/device/trezor.py
@@ -1,6 +1,7 @@
 """TREZOR-related code (see http://bitcointrezor.com/)."""
 
 import logging
+import threading
 
 from trezorlib.btc import get_public_node
 from trezorlib.client import PassphraseSetting, get_default_client
@@ -26,30 +27,109 @@ class Trezor(interface.Device):
 
     ui = None  # can be overridden by device's users
     _session = None  # cache one session per agent process
+    _client = None  # the owning TrezorClient (holds the USB transport)
+    _lock = threading.RLock()  # guards the cached session/client and the timer
+    _idle_timer = None  # threading.Timer that releases the session when idle
+    _idle_gen = 0  # bumped on every (re)arm/cancel to invalidate stale timers
 
     @property
     def session(self):
         """Return cached session, or connect and pair if needed."""
-        if self.__class__._session is None:
-            assert self.ui is not None
-            client = get_default_client(
-                app_name="trezor-agent",
-                pin_callback=self.ui.get_pin,
-                code_entry_callback=self.ui.get_pairing_code,
-            )
-            session = client.get_session(passphrase=PassphraseSetting.AUTO)
-            log.info("%s @ fpr=%s", session, session.get_root_fingerprint().hex())
-            self.__class__._session = session
+        return self._get_session()
 
-        return self.__class__._session
+    @classmethod
+    def _get_session(cls):
+        with cls._lock:
+            if cls._session is None:
+                assert cls.ui is not None
+                client = get_default_client(
+                    app_name="trezor-agent",
+                    pin_callback=cls.ui.get_pin,
+                    code_entry_callback=cls.ui.get_pairing_code,
+                )
+                session = client.get_session(passphrase=PassphraseSetting.AUTO)
+                log.info("%s @ fpr=%s", session, session.get_root_fingerprint().hex())
+                cls._client = client
+                cls._session = session
+
+            return cls._session
 
     def connect(self):
-        """One session is cached."""
+        """Reuse the cached session, cancelling any pending idle release."""
+        self._cancel_idle_timer()
         return self
 
     def close(self):
-        """One session is cached."""
-        pass
+        """Release the cached session, immediately or after an idle delay.
+
+        Controlled by ``close_after_idle`` (see ``interface.Device``):
+        ``None`` keeps the session for the whole process (the default and the
+        historical behavior), ``0`` releases it after every operation, and
+        ``N > 0`` releases it after ``N`` seconds of inactivity. Releasing the
+        session frees the device for other applications between operations.
+        """
+        idle = self.close_after_idle
+        if idle is None:
+            return
+        if idle <= 0:
+            self._release_session()
+        else:
+            self._arm_idle_timer(idle)
+
+    @classmethod
+    def _cancel_idle_timer(cls):
+        with cls._lock:
+            cls._idle_gen += 1
+            if cls._idle_timer is not None:
+                cls._idle_timer.cancel()
+                cls._idle_timer = None
+
+    @classmethod
+    def _arm_idle_timer(cls, idle):
+        with cls._lock:
+            cls._idle_gen += 1
+            gen = cls._idle_gen
+            if cls._idle_timer is not None:
+                cls._idle_timer.cancel()
+            timer = threading.Timer(idle, cls._idle_timeout, args=(gen,))
+            timer.daemon = True
+            cls._idle_timer = timer
+            timer.start()
+
+    @classmethod
+    def _idle_timeout(cls, gen):
+        with cls._lock:
+            # A new operation may have cancelled/re-armed us after the timer
+            # fired but before it took the lock: only act if still current.
+            if gen != cls._idle_gen:
+                return
+            cls._idle_timer = None
+            cls._release_session()
+
+    @classmethod
+    def _release_session(cls):
+        """Close the cached session and release the USB transport, if any."""
+        with cls._lock:
+            cls._idle_gen += 1
+            if cls._idle_timer is not None:
+                cls._idle_timer.cancel()
+                cls._idle_timer = None
+            session, client = cls._session, cls._client
+            cls._session = None
+            cls._client = None
+            if session is None and client is None:
+                return
+            if session is not None:
+                try:
+                    session.close()
+                except Exception as e:  # pylint: disable=broad-except
+                    log.debug("ending device session failed: %s", e)
+            if client is not None:
+                try:
+                    client.transport.close()
+                except Exception as e:  # pylint: disable=broad-except
+                    log.debug("closing device transport failed: %s", e)
+            log.info("released cached device session")
 
     def pubkey(self, identity, ecdh=False):
         """Return public key."""

--- a/libagent/ssh/__init__.py
+++ b/libagent/ssh/__init__.py
@@ -101,6 +101,10 @@ def create_agent_parser(device_type):
                    help='Path to the log file (to be written by the agent).')
     p.add_argument('--sock-path', type=str,
                    help='Path to the ' + SOCK_TYPE + ' of the agent.')
+    p.add_argument('--close-after-idle', type=float, default=None, metavar='SECONDS',
+                   help='release the device after each operation (0) or after '
+                        'SECONDS of inactivity, so other applications can use '
+                        'it; by default the device is held until the agent exits.')
 
     p.add_argument('--pin-entry-binary', type=str, default=argparse.SUPPRESS,
                    help='Path to PIN entry UI helper.')
@@ -322,6 +326,8 @@ def main(device_type):
 
     # override default PIN/passphrase entry tools (relevant for TREZOR):
     device_type.ui = device.ui.UI(device_type=device_type, config=vars(args))
+    # release the device between operations, if requested (relevant for TREZOR):
+    device_type.close_after_idle = args.close_after_idle
 
     conn = JustInTimeConnection(
         conn_factory=lambda: client.Client(device_type()),

--- a/libagent/tests/test_trezor.py
+++ b/libagent/tests/test_trezor.py
@@ -1,0 +1,125 @@
+# pylint: disable=protected-access
+import mock
+import pytest
+
+try:
+    from ..device import trezor
+except ImportError:  # trezorlib is an optional dependency of libagent
+    trezor = None
+
+pytestmark = pytest.mark.skipif(trezor is None, reason='requires trezorlib')
+
+
+@pytest.fixture(autouse=True)
+def reset_session_cache():
+    """Reset the per-class session cache around each test."""
+    if trezor is None:
+        yield
+        return
+    cls = trezor.Trezor
+    cls._session = cls._client = cls._idle_timer = None
+    cls._idle_gen = 0
+    cls.close_after_idle = None
+    cls.ui = mock.Mock()
+    yield
+    if cls._idle_timer is not None:
+        cls._idle_timer.cancel()
+    cls._session = cls._client = cls._idle_timer = None
+    cls.close_after_idle = None
+
+
+def fake_client():
+    client = mock.Mock()
+    session = mock.Mock()
+    session.get_root_fingerprint.return_value = b'\xab\xcd\xef\x01'
+    client.get_session.return_value = session
+    return client, session
+
+
+def test_session_is_kept_by_default():
+    trezor.Trezor.close_after_idle = None
+    client, session = fake_client()
+    with mock.patch.object(trezor, 'get_default_client', return_value=client) as get:
+        device = trezor.Trezor()
+        with device:
+            assert device.session is session
+        with device:  # a second operation reuses the cached session
+            assert device.session is session
+    assert get.call_count == 1
+    assert trezor.Trezor._session is session
+    assert not session.close.called
+    assert not client.transport.close.called
+
+
+def test_release_after_each_operation():
+    trezor.Trezor.close_after_idle = 0
+    client, session = fake_client()
+    with mock.patch.object(trezor, 'get_default_client', return_value=client):
+        device = trezor.Trezor()
+        with device:
+            assert device.session is session
+    assert trezor.Trezor._session is None
+    assert trezor.Trezor._client is None
+    assert session.close.called
+    assert client.transport.close.called
+
+
+def test_release_survives_failures_when_closing():
+    trezor.Trezor.close_after_idle = 0
+    client, session = fake_client()
+    session.close.side_effect = RuntimeError('boom')
+    client.transport.close.side_effect = RuntimeError('boom')
+    with mock.patch.object(trezor, 'get_default_client', return_value=client):
+        device = trezor.Trezor()
+        with device:
+            assert device.session is session
+    # even if the device errors while closing, the cache is cleared
+    assert trezor.Trezor._session is None
+    assert trezor.Trezor._client is None
+
+
+def test_idle_timer_is_armed_then_cancelled_by_next_operation():
+    trezor.Trezor.close_after_idle = 100
+    client, session = fake_client()
+    with mock.patch.object(trezor, 'get_default_client', return_value=client):
+        device = trezor.Trezor()
+        with device:
+            assert device.session is session
+        # close() armed a release but kept the session for now
+        assert trezor.Trezor._idle_timer is not None
+        assert trezor.Trezor._session is session
+        # the next operation cancels the pending release
+        device.connect()
+        assert trezor.Trezor._idle_timer is None
+        assert trezor.Trezor._session is session
+    assert not client.transport.close.called
+
+
+def test_idle_timeout_releases_the_session():
+    trezor.Trezor.close_after_idle = 100
+    client, session = fake_client()
+    with mock.patch.object(trezor, 'get_default_client', return_value=client):
+        device = trezor.Trezor()
+        with device:
+            assert device.session is session
+        gen = trezor.Trezor._idle_gen
+        trezor.Trezor._idle_timer.cancel()  # fire deterministically below
+        trezor.Trezor._idle_timeout(gen)
+    assert trezor.Trezor._session is None
+    assert session.close.called
+    assert client.transport.close.called
+
+
+def test_stale_idle_timeout_is_ignored():
+    trezor.Trezor.close_after_idle = 100
+    client, session = fake_client()
+    with mock.patch.object(trezor, 'get_default_client', return_value=client):
+        device = trezor.Trezor()
+        with device:
+            assert device.session is session
+        stale_gen = trezor.Trezor._idle_gen
+        device.connect()  # cancels and bumps the generation
+        # a timer that fired just before connect() must not release the session
+        trezor.Trezor._idle_timeout(stale_gen)
+    assert trezor.Trezor._session is session
+    assert not session.close.called


### PR DESCRIPTION
A resident `trezor-agent` never lets go of the device. The Trezor backend caches one session per process as a class attribute; `connect()` opens nothing and `close()` is a no-op, and `ssh/client.py` wraps each operation in `with self.device:` whose enter/exit therefore release nothing. So once the agent has talked to the device, it holds the session for its whole lifetime and **no other application can use the device** (Trezor Suite, another agent, etc.) until the agent is killed. That's a real problem for a long-running agent.

This adds `--close-after-idle SECONDS` so `close()` can actually close:

- unset (default) — keep the session for the agent's lifetime (**unchanged**);
- `0` — release the session after every operation;
- `N > 0` — release it after `N` seconds of inactivity.

Releasing ends the device session (`Session.close()`) and closes the USB transport (`client.transport.close()`); the next operation transparently reconnects (and re-prompts for PIN/passphrase as usual). The idle release runs on a `threading.Timer` that each new operation cancels; a generation counter ensures a timer that fires during a just-started operation can't tear down its session, and all session/timer state is guarded by a lock since SSH connections are handled concurrently.

The knob lives on `interface.Device` (default `None`, honored by backends that cache a session); the SSH agent wires up the new flag.

**Compatibility:** default behavior is unchanged — the device is only released when you opt in with `--close-after-idle`.

Includes unit tests for all three modes plus the timer's arm / cancel / stale-fire / error-during-close paths (skipped when `trezorlib` isn't installed).
